### PR TITLE
ignore unused-parameter warning in ROS 1 message headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,12 @@ function(build_executable executable)
   endforeach()
 endfunction()
 
+if(NOT WIN32)
+  # ignore warning in ROS 1 message headers
+  # TODO(dirk-thomas) should only be applied to the generated_factories.cpp
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
+endif()
+
 build_executable(ros1_bridge_talker src/talker.cpp
   TARGET_DEPENDENCIES "std_msgs")
 build_executable(ros1_bridge_listener src/listener.cpp
@@ -88,7 +94,7 @@ build_executable(simple_bridge src/simple_bridge.cpp
   ROS1_DEPENDENCIES
   TARGET_DEPENDENCIES "std_msgs")
 
-# TODO until the generated file can be passed to add_executable
+# TODO(dirk-thomas) until the generated file can be passed to add_executable
 # this must be a custom target instead of a custom command
 add_custom_target(generate_factories
   COMMAND ${PYTHON_EXECUTABLE} bin/ros1_bridge_generate_factories


### PR DESCRIPTION
Before http://ci.ros2.org/view/packaging/job/ros2_packaging_osx/17/
After http://ci.ros2.org/view/packaging/job/ros2_packaging_osx/19/