### PR TITLE
fix build of bridge for namespace change

### DIFF
--- a/src/simple_bridge.cpp
+++ b/src/simple_bridge.cpp
@@ -38,7 +38,7 @@ void ros2ChatterCallback(const std_msgs::msg::String::SharedPtr ros2_msg)
 }
 
 
-publisher::Publisher<std_msgs::msg::String>::SharedPtr ros2_pub;
+rclcpp::publisher::Publisher<std_msgs::msg::String>::SharedPtr ros2_pub;
 
 void ros1ChatterCallback(const ros::MessageEvent<std_msgs::String const> & ros1_msg_event)
 {

--- a/src/simple_bridge_1_to_2.cpp
+++ b/src/simple_bridge_1_to_2.cpp
@@ -23,7 +23,7 @@
 #include "std_msgs/msg/string.hpp"
 
 
-publisher::Publisher<std_msgs::msg::String>::SharedPtr pub;
+rclcpp::publisher::Publisher<std_msgs::msg::String>::SharedPtr pub;
 
 void chatterCallback(const std_msgs::String::ConstPtr & ros1_msg)
 {


### PR DESCRIPTION
Packaging jobs (because the CI jobs don't build the bridge):

* http://ci.ros2.org/view/packaging/job/packaging_osx/25
* http://ci.ros2.org/view/packaging/job/packaging_linux/49

Windows doesn't build the bridge, so this change has no effect there.