### PR TITLE
Add option for bridging all topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ ament_package()
 
 set(generated_path "${CMAKE_BINARY_DIR}/generated")
 set(generated_files "${generated_path}/get_factory.cpp")
+list(APPEND generated_files "${generated_path}/get_mappings.cpp")
 
 # generate per package compilation units to keep the memory usage low
 ament_index_get_resources(message_packages "rosidl_interfaces")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ If you would like to use a bridge with other interfaces (including your own cust
 
 *Note:* For binary releases up to and including `release-alpha8`, some of the interfaces in `common_interfaces` are skipped - check the git tag of the release in question to see which interfaces were built.
 
+For efficiency reasons, topics will only be bridged when matching publisher-subscriber pairs are active for a topic on either side of the bridge.
+You can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
+Run `dynamic_bridge --help` for more options.
 
 ## Prerequisites
 

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -46,6 +46,16 @@ struct BridgeHandles
   Bridge2to1Handles bridge2to1;
 };
 
+bool
+get_1to2_mapping(
+  const std::string & ros1_type_name,
+  std::string & ros2_type_name);
+
+bool
+get_2to1_mapping(
+  const std::string & ros2_type_name,
+  std::string & ros1_type_name);
+
 std::shared_ptr<FactoryInterface>
 get_factory(
   const std::string & ros1_type_name,

--- a/resource/get_mappings.cpp.em
+++ b/resource/get_mappings.cpp.em
@@ -1,0 +1,61 @@
+// generated from ros1_bridge/resource/get_mappings.cpp.em
+
+@###############################################
+@#
+@# Methods for determing mappings between
+@# ROS 1 and ROS 2 interfaces
+@#
+@# EmPy template for generating get_mappings.cpp
+@#
+@###############################################
+@# Start of Template
+@#
+@# Context:
+@#  - mappings (list of ros1_bridge.Mapping)
+@#    Mapping between messages as well as their fields
+@###############################################
+@
+#include <string>
+
+namespace ros1_bridge
+{
+
+bool
+get_1to2_mapping(const std::string & ros1_type_name, std::string & ros2_type_name)
+{
+@[if not mappings]@
+  (void)ros1_type_name;
+  (void)ros2_type_name;
+@[end if]@
+
+@[for m in mappings]@
+  if (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)")
+  {
+    ros2_type_name = "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)";
+    return true;
+  }
+@[end for]@
+
+  return false;
+}
+
+bool
+get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_name)
+{
+@[if not mappings]@
+  (void)ros1_type_name;
+  (void)ros2_type_name;
+@[end if]@
+
+@[for m in mappings]@
+  if (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
+  {
+    ros1_type_name = "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)";
+    return true;
+  }
+@[end for]@
+
+  return false;
+}
+
+}  // namespace ros1_bridge

--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -39,44 +39,6 @@ from ros1_bridge import camel_case_to_lower_case_underscore
 namespace ros1_bridge
 {
 
-bool
-get_1to2_mapping(const std::string & ros1_type_name, std::string & ros2_type_name)
-{
-@[if not mappings]@
-  (void)ros1_type_name;
-  (void)ros2_type_name;
-@[end if]@
-
-@[for m in mappings]@
-  if (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)")
-  {
-    ros2_type_name = "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)";
-    return true;
-  }
-@[end for]@
-
-  return false;
-}
-
-bool
-get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_name)
-{
-@[if not mappings]@
-  (void)ros1_type_name;
-  (void)ros2_type_name;
-@[end if]@
-
-@[for m in mappings]@
-  if (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
-  {
-    ros1_type_name = "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)";
-    return true;
-  }
-@[end for]@
-
-  return false;
-}
-
 std::shared_ptr<FactoryInterface>
 get_factory_@(ros2_package_name)(const std::string & ros1_type_name, const std::string & ros2_type_name)
 {

--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -39,6 +39,44 @@ from ros1_bridge import camel_case_to_lower_case_underscore
 namespace ros1_bridge
 {
 
+bool
+get_1to2_mapping(const std::string & ros1_type_name, std::string & ros2_type_name)
+{
+@[if not mappings]@
+  (void)ros1_type_name;
+  (void)ros2_type_name;
+@[end if]@
+
+@[for m in mappings]@
+  if (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)")
+  {
+    ros2_type_name = "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)";
+    return true;
+  }
+@[end for]@
+
+  return false;
+}
+
+bool
+get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_name)
+{
+@[if not mappings]@
+  (void)ros1_type_name;
+  (void)ros2_type_name;
+@[end if]@
+
+@[for m in mappings]@
+  if (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
+  {
+    ros1_type_name = "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)";
+    return true;
+  }
+@[end for]@
+
+  return false;
+}
+
 std::shared_ptr<FactoryInterface>
 get_factory_@(ros2_package_name)(const std::string & ros1_type_name, const std::string & ros2_type_name)
 {

--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -51,8 +51,7 @@ get_factory_@(ros2_package_name)(const std::string & ros1_type_name, const std::
   if (
     (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)" ||
      ros1_type_name == "") &&
-    ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)"
-  )
+    ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
   {
     return std::make_shared<
       Factory<

--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -85,15 +85,12 @@ get_factory_@(ros2_package_name)(const std::string & ros1_type_name, const std::
   (void)ros2_type_name;
 @[end if]@
   // mapping from string to specialized template
-  if (ros1_type_name == "" && ros2_type_name == "") {
-    throw std::runtime_error("ros1_type_name and ros2_type_name cannot both be \"\"");
-  }
 @[for m in mappings]@
   if (
     (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)" ||
      ros1_type_name == "") &&
-    (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)" ||
-     ros2_type_name == "") )
+    ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)"
+  )
   {
     return std::make_shared<
       Factory<

--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -47,11 +47,15 @@ get_factory_@(ros2_package_name)(const std::string & ros1_type_name, const std::
   (void)ros2_type_name;
 @[end if]@
   // mapping from string to specialized template
+  if (ros1_type_name == "" && ros2_type_name == "") {
+    throw std::runtime_error("ros1_type_name and ros2_type_name cannot both be \"\"");
+  }
 @[for m in mappings]@
   if (
     (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)" ||
      ros1_type_name == "") &&
-    ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
+    (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)" ||
+     ros2_type_name == "") )
   {
     return std::make_shared<
       Factory<

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -72,9 +72,14 @@ def generate_cpp(output_path, template_dir):
     data.update(generate_services())
     unique_package_names = set(data["ros2_package_names_msg"] + data["ros2_package_names_srv"])
     data["ros2_package_names"] = list(unique_package_names)
+
     template_file = os.path.join(template_dir, 'get_factory.cpp.em')
     output_file = os.path.join(output_path, 'get_factory.cpp')
     expand_template(template_file, data, output_file)
+
+    template_file = os.path.join(template_dir, 'get_mappings.cpp.em')
+    expand_template(template_file, data, os.path.join(output_path, 'get_mappings.cpp'))
+
     for ros2_package_name in data["ros2_package_names"]:
         for extension in ['cpp', 'hpp']:
             data_pkg = {
@@ -150,6 +155,7 @@ def generate_messages():
         'mappings': ordered_mappings,
         'ros2_package_names_msg': ros2_package_names
     }
+
 
 def generate_services():
     ros1_srvs = get_ros1_services()

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -69,6 +69,12 @@ import rosmsg
 
 def generate_cpp(output_path, template_dir):
     data = generate_messages()
+
+    template_file = os.path.join(template_dir, 'get_mappings.cpp.em')
+    output_file = os.path.join(output_path, 'get_mappings.cpp')
+    data_for_template = {'mappings': data['mappings']}
+    expand_template(template_file, data_for_template, output_file)
+
     data.update(generate_services())
     unique_package_names = set(data["ros2_package_names_msg"] + data["ros2_package_names_srv"])
     data["ros2_package_names"] = list(unique_package_names)
@@ -76,9 +82,6 @@ def generate_cpp(output_path, template_dir):
     template_file = os.path.join(template_dir, 'get_factory.cpp.em')
     output_file = os.path.join(output_path, 'get_factory.cpp')
     expand_template(template_file, data, output_file)
-
-    template_file = os.path.join(template_dir, 'get_mappings.cpp.em')
-    expand_template(template_file, data, os.path.join(output_path, 'get_mappings.cpp'))
 
     for ros2_package_name in data["ros2_package_names"]:
         for extension in ['cpp', 'hpp']:

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -129,7 +129,7 @@ void update_bridge(
         continue;
       }
       // update the ROS 2 type name to be that of the anticipated bridged type
-      //TODO(dhood): support non 1-1 "bridge-all" mappings
+      // TODO(dhood): support non 1-1 "bridge-all" mappings
       bool mapping_found = ros1_bridge::get_1to2_mapping(ros1_type_name, ros2_type_name);
       if (!mapping_found) {
         // printf("No known mapping for ROS 1 type '%s'\n", ros1_type_name.c_str());
@@ -190,9 +190,9 @@ void update_bridge(
         continue;
       }
       // update the ROS 1 type name to be that of the anticipated bridged type
+      // TODO(dhood): support non 1-1 "bridge-all" mappings
       bool mapping_found = ros1_bridge::get_2to1_mapping(ros2_type_name, ros1_type_name);
-      if (!mapping_found)
-      {
+      if (!mapping_found) {
         // printf("No known mapping for ROS 2 type '%s'\n", ros2_type_name.c_str());
         continue;
       }
@@ -421,7 +421,7 @@ int main(int argc, char * argv[])
   bool bridge_all_1to2_topics;
   bool bridge_all_2to1_topics;
   if (!parse_command_options(
-    argc, argv, output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
+      argc, argv, output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
   {
     return 0;
   }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -128,8 +128,7 @@ void update_bridge(
 
     auto ros2_subscriber = ros2_subscribers.find(topic_name);
     if (ros2_subscriber == ros2_subscribers.end()) {
-      if (bridge_all_1to2_topics)
-      {
+      if (bridge_all_1to2_topics) {
         ros2_type_name = "";
         // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
       } else {
@@ -414,9 +413,10 @@ int main(int argc, char * argv[])
   bool output_topic_introspection;
   bool bridge_all_1to2_topics;
   bool bridge_all_2to1_topics;
-  if(!parse_command_options(argc, argv,
-    output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics)) {
-      return 0;
+  if (!parse_command_options(argc, argv,
+    output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
+  {
+    return 0;
   }
 
   // ROS 1 node

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -118,11 +118,13 @@ void update_bridge(
         bridge.ros1_type_name, topic_name, 10,
         bridge.ros2_type_name, topic_name, 10);
     } catch (std::runtime_error & e) {
+      if (bridge.ros2_type_name != "") {
       fprintf(
         stderr,
         "failed to create 1to2 bridge for topic '%s' "
         "with ROS 1 type '%s' and ROS 2 type '%s': %s\n",
         topic_name.c_str(), bridge.ros1_type_name.c_str(), bridge.ros2_type_name.c_str(), e.what());
+      }
       continue;
     }
 
@@ -176,11 +178,13 @@ void update_bridge(
         bridge.ros2_type_name, topic_name, 10,
         bridge.ros1_type_name, topic_name, 10);
     } catch (std::runtime_error & e) {
+      if (bridge.ros1_type_name != "") {
       fprintf(
         stderr,
         "failed to create 2to1 bridge for topic '%s' "
         "with ROS 2 type '%s' and ROS 1 type '%s': %s\n",
         topic_name.c_str(), bridge.ros2_type_name.c_str(), bridge.ros1_type_name.c_str(), e.what());
+      }
       continue;
     }
 

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -124,16 +124,16 @@ void update_bridge(
   }
 
   // create 2to1 bridges
-  for (auto ros1_subscriber : ros1_subscribers) {
+  for (auto ros2_publisher : ros2_publishers) {
     // identify topics available as ROS 1 subscribers as well as ROS 2 publishers
-    auto topic_name = ros1_subscriber.first;
-    auto ros2_publisher = ros2_publishers.find(topic_name);
-    if (ros2_publisher == ros2_publishers.end()) {
+    auto topic_name = ros2_publisher.first;
+    auto ros1_subscriber = ros1_subscribers.find(topic_name);
+    if (ros1_subscriber == ros1_subscribers.end()) {
       continue;
     }
 
-    std::string ros1_type_name = ros1_subscriber.second;
-    std::string ros2_type_name = ros2_publisher->second;
+    std::string ros1_type_name = ros1_subscriber->second;
+    std::string ros2_type_name = ros2_publisher.second;
     // printf("topic name '%s' has ROS 1 subscribers and ROS 2 publishers\n", topic_name.c_str());
 
     // check if 2to1 bridge for the topic exists

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -162,13 +162,11 @@ void update_bridge(
         bridge.ros1_type_name, topic_name, 10,
         bridge.ros2_type_name, topic_name, 10);
     } catch (std::runtime_error & e) {
-      if (bridge.ros2_type_name != "") {
       fprintf(
         stderr,
         "failed to create 1to2 bridge for topic '%s' "
         "with ROS 1 type '%s' and ROS 2 type '%s': %s\n",
         topic_name.c_str(), bridge.ros1_type_name.c_str(), bridge.ros2_type_name.c_str(), e.what());
-      }
       continue;
     }
 
@@ -222,13 +220,11 @@ void update_bridge(
         bridge.ros2_type_name, topic_name, 10,
         bridge.ros1_type_name, topic_name, 10);
     } catch (std::runtime_error & e) {
-      if (bridge.ros1_type_name != "") {
       fprintf(
         stderr,
         "failed to create 2to1 bridge for topic '%s' "
         "with ROS 2 type '%s' and ROS 1 type '%s': %s\n",
         topic_name.c_str(), bridge.ros2_type_name.c_str(), bridge.ros1_type_name.c_str(), e.what());
-      }
       continue;
     }
 

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -65,10 +65,7 @@ bool find_command_option(const std::vector<std::string> & args, const std::strin
 bool get_flag_option(const std::vector<std::string> & args, const std::string & option)
 {
   auto it = std::find(args.begin(), args.end(), option);
-  if (it != args.end()) {
-    return true;
-  }
-  return false;
+  return it != args.end();
 }
 
 bool parse_command_options(
@@ -128,17 +125,17 @@ void update_bridge(
 
     auto ros2_subscriber = ros2_subscribers.find(topic_name);
     if (ros2_subscriber == ros2_subscribers.end()) {
-      if (bridge_all_1to2_topics) {
-        // update the ROS 2 type name to be the anticipate the bridged type
-        bool mapping_found = ros1_bridge::get_1to2_mapping(ros1_type_name, ros2_type_name);
-        if (!mapping_found) {
-          // printf("No known mapping for ROS 1 type '%s'\n", ros1_type_name.c_str());
-          continue;
-        }
-        // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
-      } else {
+      if (!bridge_all_1to2_topics) {
         continue;
       }
+      // update the ROS 2 type name to be that of the anticipated bridged type
+      //TODO(dhood): support non 1-1 "bridge-all" mappings
+      bool mapping_found = ros1_bridge::get_1to2_mapping(ros1_type_name, ros2_type_name);
+      if (!mapping_found) {
+        // printf("No known mapping for ROS 1 type '%s'\n", ros1_type_name.c_str());
+        continue;
+      }
+      // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
     } else {
       ros2_type_name = ros2_subscriber->second;
       // printf("topic name '%s' has ROS 1 publishers and ROS 2 subscribers\n", topic_name.c_str());
@@ -189,18 +186,17 @@ void update_bridge(
 
     auto ros1_subscriber = ros1_subscribers.find(topic_name);
     if (ros1_subscriber == ros1_subscribers.end()) {
-      if (bridge_all_2to1_topics) {
-        // update the ROS 1 type name to be the anticipate the bridged type
-        bool mapping_found = ros1_bridge::get_2to1_mapping(ros2_type_name, ros1_type_name);
-        if (!mapping_found)
-        {
-          // printf("No known mapping for ROS 2 type '%s'\n", ros2_type_name.c_str());
-          continue;
-        }
-        // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
-      } else {
+      if (!bridge_all_2to1_topics) {
         continue;
       }
+      // update the ROS 1 type name to be that of the anticipated bridged type
+      bool mapping_found = ros1_bridge::get_2to1_mapping(ros2_type_name, ros1_type_name);
+      if (!mapping_found)
+      {
+        // printf("No known mapping for ROS 2 type '%s'\n", ros2_type_name.c_str());
+        continue;
+      }
+      // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
     } else {
       ros1_type_name = ros1_subscriber->second;
       // printf("topic name '%s' has ROS 1 subscribers and ROS 2 publishers\n", topic_name.c_str());
@@ -424,8 +420,8 @@ int main(int argc, char * argv[])
   bool output_topic_introspection;
   bool bridge_all_1to2_topics;
   bool bridge_all_2to1_topics;
-  if (!parse_command_options(argc, argv,
-    output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
+  if (!parse_command_options(
+    argc, argv, output_topic_introspection, bridge_all_1to2_topics, bridge_all_2to1_topics))
   {
     return 0;
   }

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -129,7 +129,12 @@ void update_bridge(
     auto ros2_subscriber = ros2_subscribers.find(topic_name);
     if (ros2_subscriber == ros2_subscribers.end()) {
       if (bridge_all_1to2_topics) {
-        ros2_type_name = "";
+        // update the ROS 2 type name to be the anticipate the bridged type
+        bool mapping_found = ros1_bridge::get_1to2_mapping(ros1_type_name, ros2_type_name);
+        if (!mapping_found) {
+          // printf("No known mapping for ROS 1 type '%s'\n", ros1_type_name.c_str());
+          continue;
+        }
         // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
       } else {
         continue;
@@ -185,7 +190,13 @@ void update_bridge(
     auto ros1_subscriber = ros1_subscribers.find(topic_name);
     if (ros1_subscriber == ros1_subscribers.end()) {
       if (bridge_all_2to1_topics) {
-        ros1_type_name = "";
+        // update the ROS 1 type name to be the anticipate the bridged type
+        bool mapping_found = ros1_bridge::get_2to1_mapping(ros2_type_name, ros1_type_name);
+        if (!mapping_found)
+        {
+          // printf("No known mapping for ROS 2 type '%s'\n", ros2_type_name.c_str());
+          continue;
+        }
         // printf("topic name '%s' has ROS 2 publishers\n", topic_name.c_str());
       } else {
         continue;


### PR DESCRIPTION
without this, getting a topic to be bridged requires starting up temporary subscribers on the other side. introspection tools e.g. `rostopic list` can't see ROS 2 publishers, and tools such as `rosbag record --all` aren't very usable.

With this, bridges will be made for any topic that has a known mapping, whether subscribers are on the other side or not.

right now it is trying to make a bridge for a topic even if it doesn't have a known mapping, so you get e.g. `failed to create 1to2 bridge for topic 'rosout_agg' with ROS 1 type 'rosgraph_msgs/Log' and ROS 2 type '': No template specialization for the pair` printed out. I will fix it by adding a function that check if a factory exists for the type before forcibly creating the mapping.