### PR TITLE
add option to dynamic_bridge to print out message type pairs

### DIFF
--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -15,6 +15,7 @@
 #ifndef ROS1_BRIDGE__BRIDGE_HPP_
 #define ROS1_BRIDGE__BRIDGE_HPP_
 
+#include <map>
 #include <memory>
 #include <string>
 
@@ -56,6 +57,9 @@ bool
 get_2to1_mapping(
   const std::string & ros2_type_name,
   std::string & ros1_type_name);
+
+std::map<std::string, std::string>
+get_all_mappings_2to1();
 
 std::shared_ptr<FactoryInterface>
 get_factory(

--- a/resource/get_mappings.cpp.em
+++ b/resource/get_mappings.cpp.em
@@ -15,6 +15,7 @@
 @#    Mapping between messages as well as their fields
 @###############################################
 @
+#include <map>
 #include <string>
 
 namespace ros1_bridge
@@ -56,6 +57,20 @@ get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_nam
 @[end for]@
 
   return false;
+}
+
+std::map<std::string, std::string>
+get_all_mappings_2to1()
+{
+  static std::map<std::string, std::string> mappings = {
+@[for m in mappings]@
+    {
+      "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)",  // ROS 2
+      "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)"   // ROS 1
+    },
+@[end for]@
+  };
+  return mappings;
 }
 
 }  // namespace ros1_bridge

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -186,6 +186,9 @@ void update_bridge(
         "failed to create 1to2 bridge for topic '%s' "
         "with ROS 1 type '%s' and ROS 2 type '%s': %s\n",
         topic_name.c_str(), bridge.ros1_type_name.c_str(), bridge.ros2_type_name.c_str(), e.what());
+      if (std::string(e.what()).find("No template specialization") != std::string::npos) {
+        fprintf(stderr, "check the list of supported pairs with the `--print-pairs` option\n");
+      }
       continue;
     }
 
@@ -249,6 +252,9 @@ void update_bridge(
         "failed to create 2to1 bridge for topic '%s' "
         "with ROS 2 type '%s' and ROS 1 type '%s': %s\n",
         topic_name.c_str(), bridge.ros2_type_name.c_str(), bridge.ros1_type_name.c_str(), e.what());
+      if (std::string(e.what()).find("No template specialization") != std::string::npos) {
+        fprintf(stderr, "check the list of supported pairs with the `--print-pairs` option\n");
+      }
       continue;
     }
 

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -83,7 +83,7 @@ bool parse_command_options(
     ss << " -h, --help: This message." << std::endl;
     ss << " --show-introspection: Print output of introspection of both sides of the bridge.";
     ss << std::endl;
-    ss << " --print-pairs: Print output a list of the supported ROS 2 <=> ROS 1 conversion pairs.";
+    ss << " --print-pairs: Print a list of the supported ROS 2 <=> ROS 1 conversion pairs.";
     ss << std::endl;
     ss << " --bridge-all-topics: Bridge all topics in both directions, whether or not there is ";
     ss << "a matching subscriber." << std::endl;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -83,6 +83,8 @@ bool parse_command_options(
     ss << " -h, --help: This message." << std::endl;
     ss << " --show-introspection: Print output of introspection of both sides of the bridge.";
     ss << std::endl;
+    ss << " --print-pairs: Print output a list of the supported ROS 2 <=> ROS 1 conversion pairs.";
+    ss << std::endl;
     ss << " --bridge-all-topics: Bridge all topics in both directions, whether or not there is ";
     ss << "a matching subscriber." << std::endl;
     ss << " --bridge-all-1to2-topics: Bridge all ROS 1 topics to ROS 2, whether or not there is ";
@@ -90,6 +92,19 @@ bool parse_command_options(
     ss << " --bridge-all-2to1-topics: Bridge all ROS 2 topics to ROS 1, whether or not there is ";
     ss << "a matching subscriber." << std::endl;
     std::cout << ss.str();
+    return false;
+  }
+
+  if (get_flag_option(args, "--print-pairs")) {
+    auto mappings_2to1 = ros1_bridge::get_all_mappings_2to1();
+    if (mappings_2to1.size() > 0) {
+      printf("Supported ROS 2 <=> ROS 1 message type conversion pairs:\n");
+      for (auto & pair : mappings_2to1) {
+        printf("  - '%s' (ROS 2) <=> '%s' (ROS 1)\n", pair.first.c_str(), pair.second.c_str());
+      }
+    } else {
+      printf("No message type conversion pairs supported.\n");
+    }
     return false;
   }
 


### PR DESCRIPTION
For example:

```
% dynamic_bridge --print-pairs
Supported ROS 2 <=> ROS 1 message type conversion pairs:
  - 'diagnostic_msgs/DiagnosticArray' (ROS 2) <=> 'diagnostic_msgs/DiagnosticArray' (ROS 1)
  - 'diagnostic_msgs/DiagnosticStatus' (ROS 2) <=> 'diagnostic_msgs/DiagnosticStatus' (ROS 1)
  - 'diagnostic_msgs/KeyValue' (ROS 2) <=> 'diagnostic_msgs/KeyValue' (ROS 1)
  - 'geometry_msgs/Point' (ROS 2) <=> 'geometry_msgs/Point' (ROS 1)
  - 'geometry_msgs/Point32' (ROS 2) <=> 'geometry_msgs/Point32' (ROS 1)
  - 'geometry_msgs/PointStamped' (ROS 2) <=> 'geometry_msgs/PointStamped' (ROS 1)
  - 'geometry_msgs/Polygon' (ROS 2) <=> 'geometry_msgs/Polygon' (ROS 1)
  - 'geometry_msgs/PolygonStamped' (ROS 2) <=> 'geometry_msgs/PolygonStamped' (ROS 1)
  - 'geometry_msgs/Pose' (ROS 2) <=> 'geometry_msgs/Pose' (ROS 1)
  - 'geometry_msgs/Pose2D' (ROS 2) <=> 'geometry_msgs/Pose2D' (ROS 1)
  - 'geometry_msgs/PoseArray' (ROS 2) <=> 'geometry_msgs/PoseArray' (ROS 1)
  - 'geometry_msgs/PoseStamped' (ROS 2) <=> 'geometry_msgs/PoseStamped' (ROS 1)
  - 'geometry_msgs/PoseWithCovariance' (ROS 2) <=> 'geometry_msgs/PoseWithCovariance' (ROS 1)
  - 'geometry_msgs/PoseWithCovarianceStamped' (ROS 2) <=> 'geometry_msgs/PoseWithCovarianceStamped' (ROS 1)
  - 'geometry_msgs/Quaternion' (ROS 2) <=> 'geometry_msgs/Quaternion' (ROS 1)
  - 'geometry_msgs/QuaternionStamped' (ROS 2) <=> 'geometry_msgs/QuaternionStamped' (ROS 1)
  - 'geometry_msgs/Transform' (ROS 2) <=> 'geometry_msgs/Transform' (ROS 1)
  - 'geometry_msgs/TransformStamped' (ROS 2) <=> 'geometry_msgs/TransformStamped' (ROS 1)
  - 'geometry_msgs/Twist' (ROS 2) <=> 'geometry_msgs/Twist' (ROS 1)
  - 'geometry_msgs/TwistStamped' (ROS 2) <=> 'geometry_msgs/TwistStamped' (ROS 1)
  - 'geometry_msgs/TwistWithCovariance' (ROS 2) <=> 'geometry_msgs/TwistWithCovariance' (ROS 1)
  - 'geometry_msgs/TwistWithCovarianceStamped' (ROS 2) <=> 'geometry_msgs/TwistWithCovarianceStamped' (ROS 1)
  - 'geometry_msgs/Vector3' (ROS 2) <=> 'geometry_msgs/Vector3' (ROS 1)
  - 'geometry_msgs/Vector3Stamped' (ROS 2) <=> 'geometry_msgs/Vector3Stamped' (ROS 1)
  - 'geometry_msgs/Wrench' (ROS 2) <=> 'geometry_msgs/Wrench' (ROS 1)
  - 'geometry_msgs/WrenchStamped' (ROS 2) <=> 'geometry_msgs/WrenchStamped' (ROS 1)
  - 'sensor_msgs/CameraInfo' (ROS 2) <=> 'sensor_msgs/CameraInfo' (ROS 1)
  - 'sensor_msgs/ChannelFloat32' (ROS 2) <=> 'sensor_msgs/ChannelFloat32' (ROS 1)
  - 'sensor_msgs/CompressedImage' (ROS 2) <=> 'sensor_msgs/CompressedImage' (ROS 1)
  - 'sensor_msgs/FluidPressure' (ROS 2) <=> 'sensor_msgs/FluidPressure' (ROS 1)
  - 'sensor_msgs/Illuminance' (ROS 2) <=> 'sensor_msgs/Illuminance' (ROS 1)
  - 'sensor_msgs/Image' (ROS 2) <=> 'sensor_msgs/Image' (ROS 1)
  - 'sensor_msgs/Imu' (ROS 2) <=> 'sensor_msgs/Imu' (ROS 1)
  - 'sensor_msgs/JointState' (ROS 2) <=> 'sensor_msgs/JointState' (ROS 1)
  - 'sensor_msgs/Joy' (ROS 2) <=> 'sensor_msgs/Joy' (ROS 1)
  - 'sensor_msgs/JoyFeedback' (ROS 2) <=> 'sensor_msgs/JoyFeedback' (ROS 1)
  - 'sensor_msgs/JoyFeedbackArray' (ROS 2) <=> 'sensor_msgs/JoyFeedbackArray' (ROS 1)
  - 'sensor_msgs/LaserEcho' (ROS 2) <=> 'sensor_msgs/LaserEcho' (ROS 1)
  - 'sensor_msgs/LaserScan' (ROS 2) <=> 'sensor_msgs/LaserScan' (ROS 1)
  - 'sensor_msgs/MagneticField' (ROS 2) <=> 'sensor_msgs/MagneticField' (ROS 1)
  - 'sensor_msgs/MultiDOFJointState' (ROS 2) <=> 'sensor_msgs/MultiDOFJointState' (ROS 1)
  - 'sensor_msgs/MultiEchoLaserScan' (ROS 2) <=> 'sensor_msgs/MultiEchoLaserScan' (ROS 1)
  - 'sensor_msgs/NavSatFix' (ROS 2) <=> 'sensor_msgs/NavSatFix' (ROS 1)
  - 'sensor_msgs/NavSatStatus' (ROS 2) <=> 'sensor_msgs/NavSatStatus' (ROS 1)
  - 'sensor_msgs/PointCloud' (ROS 2) <=> 'sensor_msgs/PointCloud' (ROS 1)
  - 'sensor_msgs/PointCloud2' (ROS 2) <=> 'sensor_msgs/PointCloud2' (ROS 1)
  - 'sensor_msgs/PointField' (ROS 2) <=> 'sensor_msgs/PointField' (ROS 1)
  - 'sensor_msgs/Range' (ROS 2) <=> 'sensor_msgs/Range' (ROS 1)
  - 'sensor_msgs/RegionOfInterest' (ROS 2) <=> 'sensor_msgs/RegionOfInterest' (ROS 1)
  - 'sensor_msgs/RelativeHumidity' (ROS 2) <=> 'sensor_msgs/RelativeHumidity' (ROS 1)
  - 'sensor_msgs/Temperature' (ROS 2) <=> 'sensor_msgs/Temperature' (ROS 1)
  - 'sensor_msgs/TimeReference' (ROS 2) <=> 'sensor_msgs/TimeReference' (ROS 1)
  - 'std_msgs/Bool' (ROS 2) <=> 'std_msgs/Bool' (ROS 1)
  - 'std_msgs/Byte' (ROS 2) <=> 'std_msgs/Byte' (ROS 1)
  - 'std_msgs/ByteMultiArray' (ROS 2) <=> 'std_msgs/ByteMultiArray' (ROS 1)
  - 'std_msgs/Char' (ROS 2) <=> 'std_msgs/Char' (ROS 1)
  - 'std_msgs/ColorRGBA' (ROS 2) <=> 'std_msgs/ColorRGBA' (ROS 1)
  - 'std_msgs/Empty' (ROS 2) <=> 'std_msgs/Empty' (ROS 1)
  - 'std_msgs/Float32' (ROS 2) <=> 'std_msgs/Float32' (ROS 1)
  - 'std_msgs/Float32MultiArray' (ROS 2) <=> 'std_msgs/Float32MultiArray' (ROS 1)
  - 'std_msgs/Float64' (ROS 2) <=> 'std_msgs/Float64' (ROS 1)
  - 'std_msgs/Float64MultiArray' (ROS 2) <=> 'std_msgs/Float64MultiArray' (ROS 1)
  - 'std_msgs/Header' (ROS 2) <=> 'std_msgs/Header' (ROS 1)
  - 'std_msgs/Int16' (ROS 2) <=> 'std_msgs/Int16' (ROS 1)
  - 'std_msgs/Int16MultiArray' (ROS 2) <=> 'std_msgs/Int16MultiArray' (ROS 1)
  - 'std_msgs/Int32' (ROS 2) <=> 'std_msgs/Int32' (ROS 1)
  - 'std_msgs/Int32MultiArray' (ROS 2) <=> 'std_msgs/Int32MultiArray' (ROS 1)
  - 'std_msgs/Int64' (ROS 2) <=> 'std_msgs/Int64' (ROS 1)
  - 'std_msgs/Int64MultiArray' (ROS 2) <=> 'std_msgs/Int64MultiArray' (ROS 1)
  - 'std_msgs/Int8' (ROS 2) <=> 'std_msgs/Int8' (ROS 1)
  - 'std_msgs/Int8MultiArray' (ROS 2) <=> 'std_msgs/Int8MultiArray' (ROS 1)
  - 'std_msgs/MultiArrayDimension' (ROS 2) <=> 'std_msgs/MultiArrayDimension' (ROS 1)
  - 'std_msgs/MultiArrayLayout' (ROS 2) <=> 'std_msgs/MultiArrayLayout' (ROS 1)
  - 'std_msgs/String' (ROS 2) <=> 'std_msgs/String' (ROS 1)
  - 'std_msgs/UInt16' (ROS 2) <=> 'std_msgs/UInt16' (ROS 1)
  - 'std_msgs/UInt16MultiArray' (ROS 2) <=> 'std_msgs/UInt16MultiArray' (ROS 1)
  - 'std_msgs/UInt32' (ROS 2) <=> 'std_msgs/UInt32' (ROS 1)
  - 'std_msgs/UInt32MultiArray' (ROS 2) <=> 'std_msgs/UInt32MultiArray' (ROS 1)
  - 'std_msgs/UInt64' (ROS 2) <=> 'std_msgs/UInt64' (ROS 1)
  - 'std_msgs/UInt64MultiArray' (ROS 2) <=> 'std_msgs/UInt64MultiArray' (ROS 1)
  - 'std_msgs/UInt8' (ROS 2) <=> 'std_msgs/UInt8' (ROS 1)
  - 'std_msgs/UInt8MultiArray' (ROS 2) <=> 'std_msgs/UInt8MultiArray' (ROS 1)
  - 'tf2_msgs/TF2Error' (ROS 2) <=> 'tf2_msgs/TF2Error' (ROS 1)
  - 'tf2_msgs/TFMessage' (ROS 2) <=> 'tf2_msgs/TFMessage' (ROS 1)
```

It also adds a hint to use this option to make sure the expected types are supported, when you get an error message about a failure to find a matching template specialization, like this one:

```
failed to create 2to1 bridge for topic 'image' with ROS 2 type 'sensor_msgs/Image' and ROS 1 type '': No template specialization for the pair
```

Things I could have done, but didn't: I didn't add support for printing the Service pairs, and I didn't make a custom error type for when no matching specialization could be found.