### PR TITLE
Fix topic matching

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -428,7 +428,8 @@ void get_ros1_service_info(
     std::string value;
     auto success = header_in.getValue(field, value);
     if (!success) {
-      fprintf(stderr, "Failed to read %s from a header\n", field.data());
+      fprintf(stderr, "Failed to read '%s' from a header for '%s'\n", field.data(), key.c_str());
+      ros1_services.erase(key);
       return;
     }
     ros1_services[key][field] = value;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -415,7 +415,7 @@ void get_ros1_service_info(
     fprintf(stderr, "Failed to read a response from a service server\n");
     return;
   }
-  std::string key(name.begin() + 1, name.end());
+  std::string key = name;
   ros1_services[key] = std::map<std::string, std::string>();
   ros::Header header_in;
   std::string error;
@@ -496,9 +496,6 @@ int main(int argc, char * argv[])
       if (payload.size() >= 1) {
         for (int j = 0; j < payload[0].size(); ++j) {
           std::string topic_name = payload[0][j][0];
-          if (topic_name.compare(0, 1, "/") == 0) {
-            topic_name = topic_name.substr(1);
-          }
           for (int k = 0; k < payload[0][j][1].size(); ++k) {
             std::string node_name = payload[0][j][1][k];
             // ignore publishers from the bridge itself
@@ -514,9 +511,6 @@ int main(int argc, char * argv[])
       if (payload.size() >= 2) {
         for (int j = 0; j < payload[1].size(); ++j) {
           std::string topic_name = payload[1][j][0];
-          if (topic_name.compare(0, 1, "/") == 0) {
-            topic_name = topic_name.substr(1);
-          }
           for (int k = 0; k < payload[1][j][1].size(); ++k) {
             std::string node_name = payload[1][j][1][k];
             // ignore subscribers from the bridge itself
@@ -535,9 +529,7 @@ int main(int argc, char * argv[])
         for (int j = 0; j < payload[2].size(); ++j) {
           if (payload[2][j][0].getType() == XmlRpc::XmlRpcValue::TypeString) {
             std::string name = payload[2][j][0];
-            if (name.find("/", 1) == std::string::npos) {
-              get_ros1_service_info(name, active_ros1_services);
-            }
+            get_ros1_service_info(name, active_ros1_services);
           }
         }
       }
@@ -558,9 +550,6 @@ int main(int argc, char * argv[])
       std::map<std::string, std::string> current_ros1_subscribers;
       for (auto topic : topics) {
         auto topic_name = topic.name;
-        if (topic_name.compare(0, 1, "/") == 0) {
-          topic_name = topic_name.substr(1);
-        }
         bool has_publisher = active_publishers.find(topic_name) != active_publishers.end();
         bool has_subscriber = active_subscribers.find(topic_name) != active_subscribers.end();
         if (!has_publisher && !has_subscriber) {

--- a/test/test_dynamic_bridge.py.in
+++ b/test/test_dynamic_bridge.py.in
@@ -99,10 +99,10 @@ def launch(name, process1, process2, env1=None, env2=None, exit_handler2=None, e
     if expected_output2 is not None:
         output_handlers = [
             ConsoleOutput(),
-              InMemoryHandler(
-                  process_name, launch_descriptor, expected_output2,
-                  regex_match=True, exit_on_match=True,
-                  filtered_rmw_implementation=TEST_BRIDGE_RMW)]
+            InMemoryHandler(
+                process_name, launch_descriptor, expected_output2,
+                regex_match=True, exit_on_match=True,
+                filtered_rmw_implementation=TEST_BRIDGE_RMW)]
     launch_descriptor.add_process(
         cmd=process2[1],
         name=process_name,


### PR DESCRIPTION
This just removes code that was inplace to adapt ros 1 topics and services that have leading `/` to ros 2 topics and services which did not, until recently.

This should fix https://github.com/ros2/build_cop/issues/28.

This should also remove the need to use `--bridge-all-topics`, @Karsten1987 @Kukanani fyi.

---

I also fixed an issue where the dynamic bridge would crash if the header info for a service was incomplete. The case was being caught and a message was being printed to stderr, but later the code would crash because there was a partially filled out entry in the map. So I just remove it when this case happens now. That prevents the crash, but I don't know why the service info is incomplete in these cases.

Packaging job:

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=12)](http://ci.ros2.org/job/ci_packaging_linux/12/)