### PR TITLE
Use multimap for get_all_mappings_2to1

### DIFF
--- a/resource/get_mappings.cpp.em
+++ b/resource/get_mappings.cpp.em
@@ -59,10 +59,10 @@ get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_nam
   return false;
 }
 
-std::map<std::string, std::string>
+std::multimap<std::string, std::string>
 get_all_mappings_2to1()
 {
-  static std::map<std::string, std::string> mappings = {
+  static std::multimap<std::string, std::string> mappings = {
 @[for m in mappings]@
     {
       "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)",  // ROS 2

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -220,6 +220,7 @@ def get_ros2_messages():
                 continue
             rule_file = os.path.join(package_path, export.attributes['mapping_rules'])
             with open(rule_file, 'r') as h:
+                print('Loading message mappings from file: %s' % rule_file)
                 for data in yaml.load(h):
                     if all(n not in data for n in ('ros1_service_name', 'ros2_service_name')):
                         try:
@@ -263,6 +264,7 @@ def get_ros2_services():
                 continue
             rule_file = os.path.join(package_path, export.attributes['mapping_rules'])
             with open(rule_file, 'r') as h:
+                print('Loading service mappings from file: %s' % rule_file)
                 for data in yaml.load(h):
                     if all(n not in data for n in ('ros1_message_name', 'ros2_message_name')):
                         try:


### PR DESCRIPTION
When custom mappings are being defined, we might have a 1-to-n mapping from ROS 1 to ROS 2. E.g. both tf2_msgs/TFMessage and tf/tfMessage mapping to tf2_msgs/TFMessage. The bridge already supports this use case, but storage of a multimap is needed to make `--print-pairs` show all supported mappings.


With this PR:
```
$ dynamic_bridge --print-pairs | grep tf

  - 'tf2_msgs/TF2Error' (ROS 2) <=> 'tf2_msgs/TF2Error' (ROS 1)

  - 'tf2_msgs/TFMessage' (ROS 2) <=> 'tf2_msgs/TFMessage' (ROS 1)

  - 'tf2_msgs/TFMessage' (ROS 2) <=> 'tf/tfMessage' (ROS 1)
```

CI from last week [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=1)](http://ci.ros2.org/job/ci_packaging_linux/1/)