### PR TITLE
handle multiple types per topic

### DIFF
--- a/test/test_ros1_client.cpp
+++ b/test/test_ros1_client.cpp
@@ -20,11 +20,11 @@
 
 int main(int argc, char ** argv)
 {
-  std::this_thread::sleep_for(std::chrono::seconds(4));
   ros::init(argc, argv, "ros1_bridge_test_client");
   ros::NodeHandle n;
   ros::ServiceClient client = n.serviceClient<diagnostic_msgs::SelfTest>(
     "ros1_bridge_test");
+  client.waitForExistence();
   diagnostic_msgs::SelfTest request;
   if (client.call(request)) {
     if (request.response.id != "ros2") {


### PR DESCRIPTION
I refactored the bridge to adapt to the new api. I also just updated it to give up if the ROS 2 side has topics with different types, for example:

```
% dynamic_bridge
warning: ignoring topic '/chatter', which has more than one type: [std_msgs/Int32, std_msgs/String]
```

Connects to ros2/ros2#361