### PR TITLE
use rosrun API to determine talker/listener path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(TEST_ROS1_BRIDGE)
   custom_executable(test_ros2_server_cpp "test/test_ros2_server.cpp")
   ament_target_dependencies("test_ros2_server_cpp${target_suffix}" "ros1_roscpp" "diagnostic_msgs")
 
-  set(TEST_BRIDGE_DYNAMIC_BRIDGE "${CMAKE_INSTALL_PREFIX}/bin/dynamic_bridge")
+  set(TEST_BRIDGE_DYNAMIC_BRIDGE "$<TARGET_FILE:dynamic_bridge>")
   set(TEST_BRIDGE_ROS2_CLIENT "$<TARGET_FILE:test_ros2_client_cpp>")
   set(TEST_BRIDGE_ROS2_SERVER "$<TARGET_FILE:test_ros2_server_cpp>")
   set(TEST_BRIDGE_RMW ${rmw_implementation})

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_parser</buildtool_depend>
 
+  <build_depend>pkg-config</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
@@ -22,7 +23,10 @@
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>demo_nodes_cpp</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>ros2run</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test/test_dynamic_bridge.py.in
+++ b/test/test_dynamic_bridge.py.in
@@ -19,6 +19,7 @@ from launch.exit_handler import ignore_signal_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import InMemoryHandler
+from ros2run.api import get_executable_path
 
 
 TEST_BRIDGE_ROS1_ENV = '@TEST_BRIDGE_ROS1_ENV@'
@@ -28,8 +29,10 @@ TEST_BRIDGE_ROS1_LISTENER = ['rosrun', 'rospy_tutorials', 'listener']
 TEST_BRIDGE_ROS1_CLIENT = '@TEST_BRIDGE_ROS1_CLIENT@'
 TEST_BRIDGE_ROS1_SERVER = '@TEST_BRIDGE_ROS1_SERVER@'
 TEST_BRIDGE_DYNAMIC_BRIDGE = '@TEST_BRIDGE_DYNAMIC_BRIDGE@'
-TEST_BRIDGE_ROS2_TALKER = 'talker'
-TEST_BRIDGE_ROS2_LISTENER = 'listener'
+TEST_BRIDGE_ROS2_TALKER = get_executable_path(
+    package_name='demo_nodes_cpp', executable_name='talker')
+TEST_BRIDGE_ROS2_LISTENER = get_executable_path(
+    package_name='demo_nodes_cpp', executable_name='listener')
 TEST_BRIDGE_ROS2_CLIENT = '@TEST_BRIDGE_ROS2_CLIENT@'
 TEST_BRIDGE_ROS2_SERVER = '@TEST_BRIDGE_ROS2_SERVER@'
 TEST_BRIDGE_RMW = '@TEST_BRIDGE_RMW@'


### PR DESCRIPTION
Depends on ros2/ros2cli#12.

Fixes ros2/build_cop#34.

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=23)](http://ci.ros2.org/job/ci_packaging_linux/23/)