### PR TITLE
Fix fd leak

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -34,6 +34,7 @@
 
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp/scope_exit.hpp"
 
 #include "ros1_bridge/bridge.hpp"
 
@@ -387,6 +388,7 @@ void get_ros1_service_info(
     return;
   }
   ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
+  auto transport_exit = rclcpp::make_scope_exit([&transport](){ transport->close(); });
   if (!transport->connect(host, port)) {
     fprintf(stderr, "Failed to connect to %s:%d\n", host.data(), port);
     return;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -388,7 +388,9 @@ void get_ros1_service_info(
     return;
   }
   ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
-  auto transport_exit = rclcpp::make_scope_exit([&transport](){ transport->close(); });
+  auto transport_exit = rclcpp::make_scope_exit([&transport]() {
+    transport->close();
+  });
   if (!transport->connect(host, port)) {
     fprintf(stderr, "Failed to connect to %s:%d\n", host.data(), port);
     return;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -388,7 +388,7 @@ void get_ros1_service_info(
     return;
   }
   ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
-  auto transport_exit = rclcpp::make_scope_exit([&transport]() {
+  auto transport_exit = rclcpp::make_scope_exit([transport]() {
     transport->close();
   });
   if (!transport->connect(host, port)) {


### PR DESCRIPTION
I tested this by doing a `ulimit -n 100` and then running the bridge. It's past 7000 msgs without the "out of file descriptors" message showing up, so I think this solves it. I was kind of surprised that the `ros::TransportTCP` destructor didn't close the socket.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2832)](http://ci.ros2.org/job/ci_linux/2832/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=336)](http://ci.ros2.org/job/ci_linux-aarch64/336/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2288)](http://ci.ros2.org/job/ci_osx/2288/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2968)](http://ci.ros2.org/job/ci_windows/2968/)