### PR TITLE
Readme fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Alternatively you can do it manually by sourcing the relevant workspaces yoursel
 Then build just the ROS 1 bridge with `-j2`:
 
 ```
-src/ament/ament_tools/scripts/ament.py build --build-tests --symlink-install -j2 --only ros1_bridge
+src/ament/ament_tools/scripts/ament.py build --build-tests --symlink-install -j2 --only ros1_bridge --force-cmake-configure
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Alternatively you can do it manually by sourcing the relevant workspaces yoursel
 # . <install-space-to-ros2-overlay-ws>/local_setup.bash
 ```
 
-Then build just the ROS 1 bridge with `-j1`:
+Then build just the ROS 1 bridge with `-j2`:
 
 ```
-src/ament/ament_tools/scripts/ament.py build --build-tests --symlink-install -j1 --only ros1_bridge
+src/ament/ament_tools/scripts/ament.py build --build-tests --symlink-install -j2 --only ros1_bridge
 ```
 
 


### PR DESCRIPTION
The first commit changes the ament invocation to use j2 to build the bridge:
 - Given that the bridge builds fine even on the Pine64 with j2. We may even we able to remove the limitation completely and provide an indication of how much RAM is used per compilation unit  and let use chose the flag matching their setup

The second commit adds `--force-cmake-configure` to the invocation given that it happens regularly that people build ROS 2, try it out and then follow the bridge instructions. At that point the package has already been built and cmake is no reran. see https://github.com/ros2/ros1_bridge/issues/82 for example