### PR TITLE
remove check for header fields request_type and response_type

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -428,7 +428,7 @@ void get_ros1_service_info(
     fprintf(stderr, "%s\n", error.data());
     return;
   }
-  for (std::string field : {"type", "request_type", "response_type"}) {
+  for (std::string field : {"type"}) {
     std::string value;
     auto success = header_in.getValue(field, value);
     if (!success) {


### PR DESCRIPTION
This was introduced with the original implementation in #36.

A non C++ client might not even set these header fields. Since the bridge doesn't even use them anywhere this patch removes them (which gets rid of the repeated warning).

This PR together with #90 should resolve #64.