### PR TITLE
Increase timeout waiting for server for ros2 client in tests

### DIFF
--- a/test/test_ros2_client.cpp
+++ b/test/test_ros2_client.cpp
@@ -27,7 +27,7 @@ int main(int argc, char ** argv)
   auto client = node->create_client<diagnostic_msgs::srv::SelfTest>("ros1_bridge_test");
   auto request = std::make_shared<diagnostic_msgs::srv::SelfTest::Request>();
 
-  if (!client->wait_for_service(4s)) {
+  if (!client->wait_for_service(20s)) {
     throw std::runtime_error("Service is not available");
   }
 


### PR DESCRIPTION
4s is not always enough, e.g.:
http://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/195/testReport/junit/(root)/test_dynamic_bridge__rmw_fastrtps_cpp_RelWithDebInfo/test_dynamic_bridge_srv_1to2/:
```
(test_dynamic_bridge_srv_1to2__dynamic_bridge) pid 43970: ['/opt/ros/kinetic/env.sh', '/home/rosbuild/ci_scripts/ws/build/ros1_bridge/dynamic_bridge'] (stderr > stdout, all > console)
(test_dynamic_bridge_srv_1to2__ros1server) pid 43973: ['/opt/ros/kinetic/env.sh', '/home/rosbuild/ci_scripts/ws/build/ros1_bridge/test_ros1_server'] (stderr > stdout, all > console)
(test_dynamic_bridge_srv_1to2__ros2client) pid 43981: ['/home/rosbuild/ci_scripts/ws/build/ros1_bridge/test_ros2_client_cpp'] (stderr > stdout, all > console)
[test_dynamic_bridge_srv_1to2__ros1server] ?[31m[ERROR] [1506936168.263634670]: [registerPublisher] Failed to contact master at [localhost:11311].  Retrying...?[0m
[test_dynamic_bridge_srv_1to2__dynamic_bridge] ?[31m[ERROR] [1506936168.361192670]: [registerPublisher] Failed to contact master at [localhost:11311].  Retrying...?[0m
[test_dynamic_bridge_srv_1to2__ros2client] terminate called after throwing an instance of 'std::runtime_error'
[test_dynamic_bridge_srv_1to2__ros2client]   what():  Service is not available
(test_dynamic_bridge_srv_1to2__ros2client) rc -6
```

ci_packaging_linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=48)](http://ci.ros2.org/job/ci_packaging_linux/48/)
ci_packaging_linux-aarch64: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux-aarch64&build=12)](http://ci.ros2.org/job/ci_packaging_linux-aarch64/12/)