### PR TITLE
Fix building of ros1_bridge against newer roscpp.

### DIFF
--- a/cmake/find_ros1_package.cmake
+++ b/cmake/find_ros1_package.cmake
@@ -29,6 +29,16 @@ macro(find_ros1_package name)
   pkg_check_modules(ros1_${name} ${_required} ${name})
   if(ros1_${name}_FOUND)
     set(_libraries "${ros1_${name}_LIBRARIES}")
+    # Prior to catkin 0.7.7, dependent libraries in the pkg-config file were always generated
+    # in the form "-l:/absolute/path/to/library".  Because of the leading "-l", this made
+    # them show up in ${ros1_${name}_LIBRARIES}.  catkin 0.7.7 and later has changed this to
+    # just be an absolute path (of the form "/absolute/path/to/library"), so we now have to
+    # look through the LDFLAGS_OTHER and add those to the libraries that we need to link with.
+    foreach(_flag ${ros1_${name}_LDFLAGS_OTHER})
+      if(IS_ABSOLUTE ${_flag})
+        list(APPEND _libraries "${_flag}")
+      endif()
+    endforeach()
     set(_library_dirs "${ros1_${name}_LIBRARY_DIRS}")
     set(ros1_${name}_LIBRARIES "")
     set(ros1_${name}_LIBRARY_DIRS "")


### PR DESCRIPTION
The comment in the code mostly explains it, but because of changes
to upstream catkin/roscpp, we need to expand the types of things
we look at for linking.  With this patch, building against
roscpp kinetic 1.12.7 and 1.12.12 works.

fixes ros2/build_cop#68

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>