### PR TITLE
cmake 3.10 compatibility: pass absolute path to file(GENERATE) function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,9 @@ macro(targets)
     @ONLY
   )
   file(GENERATE
-    OUTPUT test_dynamic_bridge${target_suffix}_$<CONFIG>.py
-    INPUT test_dynamic_bridge${target_suffix}.py.genexp)
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_dynamic_bridge${target_suffix}_$<CONFIG>.py"
+    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_dynamic_bridge${target_suffix}.py.genexp"
+  )
   ament_add_pytest_test(test_dynamic_bridge${target_suffix}
     "${CMAKE_CURRENT_BINARY_DIR}/test_dynamic_bridge${target_suffix}_$<CONFIG>.py"
     ENV RMW_IMPLEMENTAION=${rmw_implementaion}


### PR DESCRIPTION
This is needed to support cmake 3.10. We could define the policy based on the version of CMake but I preferred updating the codebase to have something compliant with all cmake versions without relying on undefined behavior.

More details at https://cmake.org/cmake/help/git-stage/policy/CMP0070.html

Example of CMake warning without this patch:
```
Policy CMP0070 is not set: Define file(GENERATE) behavior for relative
paths.  Run "cmake --help-policy CMP0070" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

file(GENERATE) given relative OUTPUT path:

  test/test_services__rmw_connext_cpp_RelWithDebInfo.py

This is not defined behavior unless CMP0070 is set to NEW.  For
compatibility with older versions of CMake, the previous undefined behavior
will be used.
```

connects to ros2/rcl#195