### PR TITLE
Map duration and time messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,9 @@ list(APPEND generated_files "${generated_path}/get_mappings.cpp")
 ament_index_get_resources(ros2_message_packages "rosidl_interfaces")
 foreach(message_package ${ros2_message_packages})
   find_package(${message_package} REQUIRED)
-  list(APPEND generated_files "${generated_path}/${message_package}_factories.cpp")
+  if(NOT "${message_package}" STREQUAL "builtin_interfaces")
+    list(APPEND generated_files "${generated_path}/${message_package}_factories.cpp")
+  endif()
 endforeach()
 
 add_custom_command(
@@ -126,6 +128,7 @@ custom_executable(simple_bridge "src/simple_bridge.cpp"
   TARGET_DEPENDENCIES "std_msgs")
 
 add_library(${PROJECT_NAME} SHARED
+  "src/builtin_interfaces_factories.cpp"
   "src/convert_builtin_interfaces.cpp"
   ${generated_files})
 ament_target_dependencies(${PROJECT_NAME}

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -1,0 +1,74 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS1_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
+#define ROS1_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
+
+#include <ros1_bridge/factory.hpp>
+
+// include ROS 1 messages
+#include <std_msgs/Duration.h>
+#include <std_msgs/Time.h>
+
+// include ROS 2 messages
+#include <builtin_interfaces/msg/duration.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+
+namespace ros1_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory_builtin_interfaces(const std::string & ros1_type_name, const std::string & ros2_type_name);
+
+// conversion functions for available interfaces
+
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::convert_1_to_2(
+  const std_msgs::Duration & ros1_msg,
+  builtin_interfaces::msg::Duration & ros2_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Duration & ros2_msg,
+  std_msgs::Duration & ros1_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::convert_1_to_2(
+  const std_msgs::Time & ros1_msg,
+  builtin_interfaces::msg::Time & ros2_msg);
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Time & ros2_msg,
+  std_msgs::Time & ros1_msg);
+
+}  // namespace ros1_bridge
+
+#endif  // ROS1_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_

--- a/include/ros1_bridge/convert_builtin_interfaces.hpp
+++ b/include/ros1_bridge/convert_builtin_interfaces.hpp
@@ -31,27 +31,26 @@ namespace ros1_bridge
 template<>
 void
 convert_1_to_2(
-  const ros::Duration & ros1_msg,
+  const ros::Duration & ros1_type,
   builtin_interfaces::msg::Duration & ros2_msg);
 
 template<>
 void
 convert_2_to_1(
   const builtin_interfaces::msg::Duration & ros2_msg,
-  ros::Duration & ros1_msg);
-
+  ros::Duration & ros1_type);
 
 template<>
 void
 convert_1_to_2(
-  const ros::Time & ros1_msg,
+  const ros::Time & ros1_type,
   builtin_interfaces::msg::Time & ros2_msg);
 
 template<>
 void
 convert_2_to_1(
   const builtin_interfaces::msg::Time & ros2_msg,
-  ros::Time & ros1_msg);
+  ros::Time & ros1_type);
 
 }  // namespace ros1_bridge
 

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_parser</buildtool_depend>
 
+  <build_depend>builtin_interfaces</build_depend>
   <build_depend>pkg-config</build_depend>
   <build_depend>python3-yaml</build_depend>
   <build_depend>rclcpp</build_depend>
@@ -19,6 +20,7 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcutils</exec_depend>

--- a/resource/get_factory.cpp.em
+++ b/resource/get_factory.cpp.em
@@ -19,6 +19,7 @@
 from ros1_bridge import camel_case_to_lower_case_underscore
 }@
 #include "ros1_bridge/factory.hpp"
+#include "ros1_bridge/builtin_interfaces_factories.hpp"
 
 @[for ros2_package_name in sorted(ros2_package_names)]@
 #include "@(ros2_package_name)_factories.hpp"
@@ -36,6 +37,10 @@ get_factory(const std::string & ros1_type_name, const std::string & ros2_type_na
 @[else]@
   std::shared_ptr<FactoryInterface> factory;
 @[end if]@
+  factory = get_factory_builtin_interfaces(ros1_type_name, ros2_type_name);
+  if (factory) {
+    return factory;
+  }
 @[for ros2_package_name in sorted(ros2_package_names)]@
   factory = get_factory_@(ros2_package_name)(ros1_type_name, ros2_type_name);
   if (factory) {

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -1,0 +1,102 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+
+// include builtin interfaces
+#include <ros1_bridge/builtin_interfaces_factories.hpp>
+#include <ros1_bridge/convert_builtin_interfaces.hpp>
+
+namespace ros1_bridge
+{
+
+std::shared_ptr<FactoryInterface>
+get_factory_builtin_interfaces(const std::string & ros1_type_name, const std::string & ros2_type_name)
+{
+  // mapping from string to specialized template
+  if (
+    (ros1_type_name == "std_msgs/Duration" || ros1_type_name == "") &&
+    ros2_type_name == "builtin_interfaces/Duration")
+  {
+    return std::make_shared<
+      Factory<
+        std_msgs::Duration,
+        builtin_interfaces::msg::Duration
+      >
+    >("std_msgs/Duration", ros2_type_name);
+  }
+  if (
+    (ros1_type_name == "std_msgs/Time" || ros1_type_name == "") &&
+    ros2_type_name == "builtin_interfaces/Time")
+  {
+    return std::make_shared<
+      Factory<
+        std_msgs::Time,
+        builtin_interfaces::msg::Time
+      >
+    >("std_msgs/Time", ros2_type_name);
+  }
+  return std::shared_ptr<FactoryInterface>();
+}
+
+// conversion functions for available interfaces
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::convert_1_to_2(
+  const std_msgs::Duration & ros1_msg,
+  builtin_interfaces::msg::Duration & ros2_msg)
+{
+  ros1_bridge::convert_1_to_2(ros1_msg.data, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Duration & ros2_msg,
+  std_msgs::Duration & ros1_msg)
+{
+  ros1_bridge::convert_2_to_1(ros2_msg, ros1_msg.data);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::convert_1_to_2(
+  const std_msgs::Time & ros1_msg,
+  builtin_interfaces::msg::Time & ros2_msg)
+{
+  ros1_bridge::convert_1_to_2(ros1_msg.data, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Time & ros2_msg,
+  std_msgs::Time & ros1_msg)
+{
+  ros1_bridge::convert_2_to_1(ros2_msg, ros1_msg.data);
+}
+
+}  // namespace ros1_bridge

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -20,42 +20,42 @@ namespace ros1_bridge
 template<>
 void
 convert_1_to_2(
-  const ros::Duration & ros1_msg,
+  const ros::Duration & ros1_type,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros2_msg.sec = ros1_msg.sec;
-  ros2_msg.nanosec = ros1_msg.nsec;
+  ros2_msg.sec = ros1_type.sec;
+  ros2_msg.nanosec = ros1_type.nsec;
 }
 
 template<>
 void
 convert_2_to_1(
   const builtin_interfaces::msg::Duration & ros2_msg,
-  ros::Duration & ros1_msg)
+  ros::Duration & ros1_type)
 {
-  ros1_msg.sec = ros2_msg.sec;
-  ros1_msg.nsec = ros2_msg.nanosec;
+  ros1_type.sec = ros2_msg.sec;
+  ros1_type.nsec = ros2_msg.nanosec;
 }
 
 
 template<>
 void
 convert_1_to_2(
-  const ros::Time & ros1_msg,
+  const ros::Time & ros1_type,
   builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros2_msg.sec = ros1_msg.sec;
-  ros2_msg.nanosec = ros1_msg.nsec;
+  ros2_msg.sec = ros1_type.sec;
+  ros2_msg.nanosec = ros1_type.nsec;
 }
 
 template<>
 void
 convert_2_to_1(
   const builtin_interfaces::msg::Time & ros2_msg,
-  ros::Time & ros1_msg)
+  ros::Time & ros1_type)
 {
-  ros1_msg.sec = ros2_msg.sec;
-  ros1_msg.nsec = ros2_msg.nanosec;
+  ros1_type.sec = ros2_msg.sec;
+  ros1_type.nsec = ros2_msg.nanosec;
 }
 
 }  // namespace ros1_bridge


### PR DESCRIPTION
Only slightly related to ros2/ros1_bridge#104.

While the bridge can already handle fields with a `Duration` or `Time` type it currently can't map the messages `std_msgs/Duration|Time` with `builtin_interfaces/Duration|Time`.

With this patch the following appears when invoking the dynamic bridge with `--print-pairs`:

```
  - 'builtin_interfaces/Duration' (ROS 2) <=> 'std_msgs/Duration' (ROS 1)
  - 'builtin_interfaces/Time' (ROS 2) <=> 'std_msgs/Time' (ROS 1)
```

And the following example works:

* ROS 1 side:
  ```
  rostopic pub /time std_msgs/Time "data:
    secs: 1 
    nsecs: 2"
  ```
* ROS 2 side:
  ```ros2 topic echo /time builtin_interfaces/Time```