### PR TITLE
use catkin_pkg to parse packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_index_python</buildtool_depend>
+  <buildtool_depend>python3-catkin-pkg-modules</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_parser</buildtool_depend>
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -18,7 +18,7 @@ import re
 import sys
 
 import ament_index_python
-from ament_package import parse_package
+from catkin_pkg.package import parse_package
 # ROS 1 imports
 import genmsg
 import genmsg.msg_loader

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -28,26 +28,8 @@ import rosidl_parser
 
 import yaml
 
-# import catkin_pkg and rospkg which are required by rosmsg
+# import rospkg which is required by rosmsg
 # and likely only available for Python 2
-try:
-    import catkin_pkg
-except ImportError:
-    from importlib.machinery import SourceFileLoader
-    import subprocess
-    for python_executable in ['python2', 'python2.7']:
-        try:
-            catkin_pkg_path = subprocess.check_output(
-                [python_executable, '-c', 'import catkin_pkg; print(catkin_pkg.__file__)'])
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            continue
-        catkin_pkg_path = catkin_pkg_path.decode().strip()
-        if catkin_pkg_path.endswith('.pyc'):
-            catkin_pkg_path = catkin_pkg_path[:-1]
-        catkin_pkg = SourceFileLoader('catkin_pkg', catkin_pkg_path).load_module()
-    if not catkin_pkg:
-        raise
-
 try:
     import rospkg
 except ImportError:


### PR DESCRIPTION
Follow-up of https://github.com/ament/ament_package/pull/75: `ament_package` doesnt provide `parse_package` anymore.

I also simplified the import of `catkin_pkg` as we now enforce the presence of the Python3 version of `catkin_pkg`.

CI will be ran after the nightlies. Placing this in review in the meantime