### PR TITLE
Changed cmake message logger level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(cmake/find_ros1_package.cmake)
 
 find_package(PkgConfig)
 if(NOT PKG_CONFIG_FOUND)
-  message(STATUS "Failed to find PkgConfig, skipping...")
+  message(WARNING "Failed to find PkgConfig, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package()
   return()
@@ -30,7 +30,7 @@ endif()
 
 find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
-  message(STATUS "Failed to find ROS 1 roscpp, skipping...")
+  message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package()
   return()


### PR DESCRIPTION


When building this package using 

`colcon build`

No message is displayed if the ros1 libraries are not found, due to the `STATUS` logger level of these CMake messages. 
Changing the logger level to `WARNING` solves the problem.