### PR TITLE
Fix for actions subfolder introduction in ros2 message bridge

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -203,7 +203,11 @@ def get_ros2_messages():
         pkgs.append(package_name)
         resource, _ = ament_index_python.get_resource(resource_type, package_name)
         interfaces = resource.splitlines()
-        message_names = [i[:-4] for i in interfaces if i.endswith('.msg')]
+        message_names = [n[4:-4] for n in interfaces if n.startswith('msg/') and n.endswith('.msg')]
+        message_names.extend(
+            [n[4:-4] for n in interfaces if n.startswith('srv/') and n.endswith('.msg')])
+        message_names.extend(
+            [n[7:-4] for n in interfaces if n.startswith('action/') and n.endswith('.msg')])
         for message_name in message_names:
             msgs.append(Message(package_name, message_name, prefix_path))
         # check package manifest for mapping rules


### PR DESCRIPTION
Relates to the change https://github.com/ros2/rosidl/commit/7d791728f36b99f08242aedd33aac05f95c64619 pointed out by @mjcarroll and @dirk-thomas which introduced packaging failures in `ros1_bridge`.

Deprecates https://github.com/ros2/rosidl/pull/319 .