### PR TITLE
expose convert function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,6 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
-ament_export_dependencies(roscpp)
-
 ament_python_install_package(${PROJECT_NAME})
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ endif()
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
+ament_export_dependencies(roscpp)
+
 ament_python_install_package(${PROJECT_NAME})
 
 ament_package()

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -105,6 +105,13 @@ public:
       topic_name, callback, custom_qos_profile, nullptr, true);
   }
 
+  void convert_1_to_2(const void * ros1_msg, void * ros2_msg) override
+  {
+    auto typed_ros1_msg = static_cast<const ROS1_T *>(ros1_msg);
+    auto typed_ros2_msg = static_cast<ROS2_T *>(ros2_msg);
+    convert_1_to_2(*typed_ros1_msg, *typed_ros2_msg);
+  }
+
 protected:
   static
   void ros1_callback(

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -112,6 +112,13 @@ public:
     convert_1_to_2(*typed_ros1_msg, *typed_ros2_msg);
   }
 
+  void convert_2_to_1(const void * ros2_msg, void * ros1_msg) override
+  {
+    auto typed_ros2_msg = static_cast<const ROS2_T *>(ros2_msg);
+    auto typed_ros1_msg = static_cast<ROS1_T *>(ros1_msg);
+    convert_2_to_1(*typed_ros2_msg, *typed_ros1_msg);
+  }
+
 protected:
   static
   void ros1_callback(

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -75,6 +75,10 @@ public:
     size_t queue_size,
     ros::Publisher ros1_pub,
     rclcpp::PublisherBase::SharedPtr ros2_pub) = 0;
+
+  virtual
+  void
+  convert_1_to_2(const void * ros1_msg, void * ros2_msg) = 0;
 };
 
 class ServiceFactoryInterface

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -79,6 +79,10 @@ public:
   virtual
   void
   convert_1_to_2(const void * ros1_msg, void * ros2_msg) = 0;
+
+  virtual
+  void
+  convert_2_to_1(const void * ros2_msg, void * ros1_msg) = 0;
 };
 
 class ServiceFactoryInterface


### PR DESCRIPTION
In order to leverage the bridge to convert ros messages from ros1 to ros2, we would like to expose this function. This allows us to convert messages without using pub/sub.

cc @botteroa-si 