### PR TITLE
add support for services in parameter_bridge and fixed-size array in service definitions

### DIFF
--- a/resource/pkg_factories.cpp.em
+++ b/resource/pkg_factories.cpp.em
@@ -235,7 +235,17 @@ void ServiceFactory<
 ) {
 @[      for field in service["fields"][type.lower()]]@
 @[        if field["array"]]@
+@[          if field["dynamic_array"]]@
+  // ensure array size
+@[            if field["upper_bound_array"] > 0]@
+  // check boundary
+@[              if frm == "1"]@
+                  assert(req@(frm).@(field["ros1"]["name"]).size() <= @(field["upper_bound_array"]));
+@[              end if]@
+@[            end if]@
+  // dynamic arrays must be resized
   req@(to).@(field["ros" + to]["name"]).resize(req@(frm).@(field["ros" + frm]["name"]).size());
+@[      end if]@
   auto @(field["ros1"]["name"])1_it = req1.@(field["ros1"]["name"]).begin();
   auto @(field["ros2"]["name"])2_it = req2.@(field["ros2"]["name"]).begin();
   while (

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -538,15 +538,18 @@ def determine_common_services(ros1_srvs, ros2_srvs, mapping_rules):
                 break
             for i, ros1_field in enumerate(ros1_fields[direction]):
                 ros1_type = ros1_field[0]
-                ros2_type = str(ros2_fields[direction][i].type)
+                ros2_type = ros2_fields[direction][i].type
                 ros1_name = ros1_field[1]
                 ros2_name = ros2_fields[direction][i].name
-                if ros1_type != ros2_type or ros1_name != ros2_name:
+                if ros1_type != str(ros2_type) or ros1_name != ros2_name:
                     match = False
                     break
+                ros2_cpptype = ros2_type.pkg_name + "::msg::" + ros2_type.type if ros2_type.pkg_name else ""
                 output[direction].append({
-                    'basic': False if '/' in ros1_type else True,
-                    'array': True if '[]' in ros1_type else False,
+                    'basic': not ros2_type.pkg_name,
+                    'array': ros2_type.is_array,
+                    'dynamic_array': not ros2_type.array_size and not ros2_type.is_upper_bound,
+                    'upper_bound_array': ros2_type.array_size if ros2_type.is_upper_bound else -1,
                     'ros1': {
                         'name': ros1_name,
                         'type': ros1_type.rstrip('[]'),
@@ -554,8 +557,8 @@ def determine_common_services(ros1_srvs, ros2_srvs, mapping_rules):
                     },
                     'ros2': {
                         'name': ros2_name,
-                        'type': ros2_type.rstrip('[]'),
-                        'cpptype': ros2_type.rstrip('[]').replace('/', '::msg::')
+                        'type': ros2_type.type,
+                        'cpptype': ros2_cpptype
                     }
                 })
         if match:

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[])
 
       try {
         ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-          ros1_node, ros2_node, type_name, type_name, topic_name, queue_size);
+          ros1_node, ros2_node, "", type_name, topic_name, queue_size);
         all_handles.push_back(handles);
       } catch (std::runtime_error & e) {
         fprintf(


### PR DESCRIPTION
This is a new version of #153 (I couldn't update the old pull request to master)

This pull request has two commits:

1. add support for fixed size array in service calls (I have tried to imitate what was doing for topics)
2. making possible to define services using the parameter_bridge, it is done very similarly to topics:
  It needs to parameter 'services_1_to_2' (for calling ROS2 services from ROS1) and 'services_2_to_1 (for calling ROS1 from ROS2), I tried to follow the naming convention of the dynamic_bridge. The parameters should look like:
    [
      {service: /name/of/service package: name_of_package_with_service, type: type_of_message},
      ...
    ]
For calling ROS1 add_two_ints from ROS2:
    [
      {service: /add_two_ints package: roscpp_tutorials, type: TwoInts}
    ]

Sorry for having two features in one pull request, it is hard for me to test one without the other, if you prefer separate pull request before inclusion, I will do that when patches are ready.

I have tested compilation with Crystal, run tests are under way.