### PR TITLE
export find_ros1_package cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
   message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
-  ament_package()
+  ament_package(
+    CONFIG_EXTRAS cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake
+  )
   return()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,9 @@ ament_export_libraries(${PROJECT_NAME})
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake
+)
 
 set(generated_path "${CMAKE_BINARY_DIR}/generated")
 set(generated_files "${generated_path}/get_factory.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # find ROS 1 packages
-list(APPEND ros1_cmake_macros cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
+set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
 include(cmake/find_ros1_package.cmake)
 
 find_package(PkgConfig)
@@ -34,7 +34,7 @@ if(NOT ros1_roscpp_FOUND)
   message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package(
-    CONFIG_EXTRAS ${ros1_cmake_macros}
+    CONFIG_EXTRAS ${cmake_extras_files}
   )
   return()
 endif()
@@ -73,7 +73,7 @@ ament_export_libraries(${PROJECT_NAME})
 ament_python_install_package(${PROJECT_NAME})
 
 ament_package(
-  CONFIG_EXTRAS ${ros1_cmake_macros}
+  CONFIG_EXTRAS ${cmake_extras_files}
 )
 
 set(generated_path "${CMAKE_BINARY_DIR}/generated")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # find ROS 1 packages
+list(APPEND ros1_cmake_macros cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
 include(cmake/find_ros1_package.cmake)
 
 find_package(PkgConfig)
@@ -33,7 +34,7 @@ if(NOT ros1_roscpp_FOUND)
   message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package(
-    CONFIG_EXTRAS cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake
+    CONFIG_EXTRAS ${ros1_cmake_macros}
   )
   return()
 endif()
@@ -72,7 +73,7 @@ ament_export_libraries(${PROJECT_NAME})
 ament_python_install_package(${PROJECT_NAME})
 
 ament_package(
-  CONFIG_EXTRAS cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake
+  CONFIG_EXTRAS ${ros1_cmake_macros}
 )
 
 set(generated_path "${CMAKE_BINARY_DIR}/generated")

--- a/cmake/find_ros1_package.cmake
+++ b/cmake/find_ros1_package.cmake
@@ -20,14 +20,7 @@ macro(find_ros1_package name)
       "${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  find_package(PkgConfig)
-  if(NOT PKG_CONFIG_FOUND)
-    message(WARNING "Failed to find PkgConfig, skipping...")
-    # call ament_package() to avoid ament_tools treating this
-    # as a plain CMake pkg
-    ament_package()
-    return()
-  endif()
+  find_package(PkgConfig REQUIRED)
   # the error message of pkg_check_modules for not found required modules
   # doesn't include the module name which is not helpful
   pkg_check_modules(ros1_${name} ${name})

--- a/cmake/find_ros1_package.cmake
+++ b/cmake/find_ros1_package.cmake
@@ -20,6 +20,14 @@ macro(find_ros1_package name)
       "${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
+  find_package(PkgConfig)
+  if(NOT PKG_CONFIG_FOUND)
+    message(WARNING "Failed to find PkgConfig, skipping...")
+    # call ament_package() to avoid ament_tools treating this
+    # as a plain CMake pkg
+    ament_package()
+    return()
+  endif()
   # the error message of pkg_check_modules for not found required modules
   # doesn't include the module name which is not helpful
   pkg_check_modules(ros1_${name} ${name})

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <build_export_depend>pkg-config</build_export_depend>
+
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclcpp</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <build_export_depend>pkg-config</build_export_depend>
+  <buildtool_export_depend>pkg-config</buildtool_export_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-yaml</exec_depend>


### PR DESCRIPTION
Signed-off-by: Karsten Knese <karsten@openrobotics.org>

I believe this is the correct fix for exporting the `find_ros1_package.cmake. This allows other packages to use this macro straight after finding the `ros1_bridge` package.
see: https://github.com/ros2/rosbag2/pull/90#discussion_r256232380

please advise how to test this patch. Also I would appreciate if this could be backported to crystal.