### PR TITLE
ensure that the diagnostic_msgs package is from ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ if(BUILD_TESTING)
   find_ros1_package(roslaunch)
   ament_lint_auto_find_test_dependencies()
   if(ros1_diagnostic_msgs_FOUND AND ros1_roslaunch_FOUND)
+    # ensure that the ROS 2 diagnostic_msgs was found by find_package
+    # and not the ROS 1 package
+    set(_ros1_diagnostic_msgs_DIR "${ros1_diagnostic_msgs_PREFIX}/share/diagnostic_msgs/cmake")
+    if("${diagnostic_msgs_DIR}" STREQUAL "${_ros1_diagnostic_msgs_DIR}")
+      message(FATAL_ERROR "Failed to find ROS 2 package 'diagnostic_msgs' $ENV{CMAKE_PREFIX_PATH}")
+    endif()
     set(TEST_ROS1_BRIDGE TRUE)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(BUILD_TESTING)
     # and not the ROS 1 package
     set(_ros1_diagnostic_msgs_DIR "${ros1_diagnostic_msgs_PREFIX}/share/diagnostic_msgs/cmake")
     if("${diagnostic_msgs_DIR}" STREQUAL "${_ros1_diagnostic_msgs_DIR}")
-      message(FATAL_ERROR "Failed to find ROS 2 package 'diagnostic_msgs' $ENV{CMAKE_PREFIX_PATH}")
+      message(FATAL_ERROR "Failed to find ROS 2 package 'diagnostic_msgs'")
     endif()
     set(TEST_ROS1_BRIDGE TRUE)
   endif()


### PR DESCRIPTION
Related to #168.

This patch improves the error behavior is the ROS 2 package `diagnostic_msgs` isn't available. Without the patch `diagnostic_msgs` is found from ROS 1 (since in ROS 2 it wasn't available) and the build fails with missing headers / symbols.