### PR TITLE
invalidate wrong cached result for diagnostic_msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ if(BUILD_TESTING)
     # and not the ROS 1 package
     set(_ros1_diagnostic_msgs_DIR "${ros1_diagnostic_msgs_PREFIX}/share/diagnostic_msgs/cmake")
     if("${diagnostic_msgs_DIR}" STREQUAL "${_ros1_diagnostic_msgs_DIR}")
+      # invalidate the cached result to retry finding the package next time
+      unset(diagnostic_msgs_DIR CACHE)
       message(FATAL_ERROR "Failed to find ROS 2 package 'diagnostic_msgs'")
     endif()
     set(TEST_ROS1_BRIDGE TRUE)


### PR DESCRIPTION
Follow up of #169.

This ensures that after finding the wrong `diagnostic_msgs` package consecutive configure runs will retry to find the package in a potentially updated environment.