### PR TITLE
[backport] export find_ros1_package cmake extras

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 
 # find ROS 1 packages
+set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
 include(cmake/find_ros1_package.cmake)
 
 find_package(PkgConfig)
@@ -32,7 +33,9 @@ find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
   message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
-  ament_package()
+  ament_package(
+    CONFIG_EXTRAS ${cmake_extras_files}
+  )
   return()
 endif()
 
@@ -69,7 +72,9 @@ ament_export_libraries(${PROJECT_NAME})
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS ${cmake_extras_files}
+)
 
 set(generated_path "${CMAKE_BINARY_DIR}/generated")
 set(generated_files "${generated_path}/get_factory.cpp")

--- a/cmake/find_ros1_package.cmake
+++ b/cmake/find_ros1_package.cmake
@@ -20,6 +20,7 @@ macro(find_ros1_package name)
       "${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
+  find_package(PkgConfig REQUIRED)
   # the error message of pkg_check_modules for not found required modules
   # doesn't include the module name which is not helpful
   pkg_check_modules(ros1_${name} ${name})

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <buildtool_export_depend>pkg-config</buildtool_export_depend>
+
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclcpp</exec_depend>


### PR DESCRIPTION
This allows other packages to use macros to find ros1 packages straight after finding the `ros1_bridge` package.
see: ros2/rosbag2#90 (comment)