### PR TITLE
Fix parameter bridge for topic if ros1 and ros2 type have a different name

### DIFF
--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -73,7 +73,7 @@ int main(int argc, char * argv[])
 
       try {
         ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-          ros1_node, ros2_node, type_name, type_name, topic_name, queue_size);
+          ros1_node, ros2_node, "", type_name, topic_name, queue_size);
         all_handles.push_back(handles);
       } catch (std::runtime_error & e) {
         fprintf(

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -68,8 +68,8 @@ int main(int argc, char * argv[])
       }
       printf(
         "Trying to create bidirectional bridge for topic ''%s' "
-        "with ROS 1 type '%s' and ROS 2 type '%s'\n",
-        topic_name.c_str(), type_name.c_str(), type_name.c_str());
+        "with ROS 2 type '%s'\n",
+        topic_name.c_str(), type_name.c_str());
 
       try {
         ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
@@ -79,8 +79,8 @@ int main(int argc, char * argv[])
         fprintf(
           stderr,
           "failed to create bidirectional bridge for topic '%s' "
-          "with ROS 1 type '%s' and ROS 2 type '%s': %s\n",
-          topic_name.c_str(), type_name.c_str(), type_name.c_str(), e.what());
+          "with ROS 2 type '%s': %s\n",
+          topic_name.c_str(), type_name.c_str(), e.what());
       }
     }
   } else {


### PR DESCRIPTION
I have set ros1 type to "" since in create_bidirectional_bridge it can find out which type to use for ros1 when only specifying ros2 type.

An alternative fix would be to allow to specify different type for ros1 and ros2 in the parameters.