### PR TITLE
Allows propagations of cmd args to rclcpp::init

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -455,13 +455,13 @@ int main(int argc, char * argv[])
     return 0;
   }
 
-  // ROS 1 node
-  ros::init(argc, argv, "ros_bridge");
-  ros::NodeHandle ros1_node;
-
   // ROS 2 node
   rclcpp::init(argc, argv);
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
+
+  // ROS 1 node
+  ros::init(argc, argv, "ros_bridge");
+  ros::NodeHandle ros1_node;
 
   // mapping of available topic names to type names
   std::map<std::string, std::string> ros1_publishers;


### PR DESCRIPTION
Signed-off-by: Gonzalo de Pedro <gonzalo@depedro.com.ar>

This changes the order of initialization of nodes. By initializing firs the ROS2 node it allows cmd args to be passed to it. 