### PR TITLE
Adds interface type to ROS2 message type name

### DIFF
--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -56,7 +56,7 @@ get_factory_@(ros2_package_name)__@(interface_type)__@(interface.message_name)(c
   if (
     (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)" ||
      ros1_type_name == "") &&
-    ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
+    ros2_type_name == "@(m.ros2_msg.package_name)/@(interface_type)/@(m.ros2_msg.message_name)")
   {
     return std::make_shared<
       Factory<


### PR DESCRIPTION
Fixes https://github.com/ros2/build_cop/issues/192. This pull request fixes ros1 bridge mapping factory template to take into account the interface type in the message type name. 

* CI packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=200)](http://ci.ros2.org/job/ci_packaging_linux/200/)
* Packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=packaging_linux&build=1459)](http://ci.ros2.org/job/packaging_linux/1459/)

Another one to be added to the list in https://github.com/ros2/ros2/issues/677. 