### PR TITLE
Use interface kind names properly in ROS2 interface type names.

### DIFF
--- a/resource/get_mappings.cpp.em
+++ b/resource/get_mappings.cpp.em
@@ -34,7 +34,7 @@ get_1to2_mapping(const std::string & ros1_type_name, std::string & ros2_type_nam
 @[for m in mappings]@
   if (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)")
   {
-    ros2_type_name = "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)";
+    ros2_type_name = "@(m.ros2_msg.package_name)/msg/@(m.ros2_msg.message_name)";
     return true;
   }
 @[end for]@
@@ -51,7 +51,7 @@ get_2to1_mapping(const std::string & ros2_type_name, std::string & ros1_type_nam
 @[end if]@
 
 @[for m in mappings]@
-  if (ros2_type_name == "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)")
+  if (ros2_type_name == "@(m.ros2_msg.package_name)/msg/@(m.ros2_msg.message_name)")
   {
     ros1_type_name = "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)";
     return true;
@@ -67,7 +67,7 @@ get_all_message_mappings_2to1()
   static std::map<std::string, std::string> mappings = {
 @[for m in mappings]@
     {
-      "@(m.ros2_msg.package_name)/@(m.ros2_msg.message_name)",  // ROS 2
+      "@(m.ros2_msg.package_name)/msg/@(m.ros2_msg.message_name)",  // ROS 2
       "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)"   // ROS 1
     },
 @[end for]@
@@ -81,7 +81,7 @@ get_all_service_mappings_2to1()
   static std::map<std::string, std::string> mappings = {
 @[for s in services]@
     {
-      "@(s['ros2_package'])/@(s['ros2_name'])",  // ROS 2
+      "@(s['ros2_package'])/srv/@(s['ros2_name'])",  // ROS 2
       "@(s['ros1_package'])/@(s['ros1_name'])"   // ROS 1
     },
 @[end for]@

--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -56,7 +56,7 @@ get_factory_@(ros2_package_name)__@(interface_type)__@(interface.message_name)(c
   if (
     (ros1_type_name == "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name)" ||
      ros1_type_name == "") &&
-    ros2_type_name == "@(m.ros2_msg.package_name)/@(interface_type)/@(m.ros2_msg.message_name)")
+    ros2_type_name == "@(m.ros2_msg.package_name)/msg/@(m.ros2_msg.message_name)")
   {
     return std::make_shared<
       Factory<
@@ -86,7 +86,7 @@ get_service_factory_@(ros2_package_name)__@(interface_type)__@(interface.message
     ) || (
       ros_id == "ros2" &&
       package_name == "@(service["ros2_package"])" &&
-      service_name == "@(service["ros2_name"])"
+      service_name == "srv/@(service["ros2_name"])"
     )
   ) {
     return std::unique_ptr<ServiceFactoryInterface>(new ServiceFactory<


### PR DESCRIPTION
Follow up after 816b667de32f6a5ab45a7cfc22b931f3d2ac1749, introduced by #191. Prefixes (i.e. `msg`, `srv`) were still missing in a few other places.

* CI packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=205)](http://ci.ros2.org/job/ci_packaging_linux/205/)

I managed to reproduce latest test failures on https://github.com/ros2/build_cop/issues/192 locally and all appear to be fixed by this patch.