### PR TITLE
Disable rosout logging for Fast-RTPS tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,10 +215,11 @@ if(TEST_ROS1_BRIDGE)
   set(TEST_BRIDGE_DYNAMIC_BRIDGE "$<TARGET_FILE:dynamic_bridge>")
   set(TEST_BRIDGE_ROS2_CLIENT "$<TARGET_FILE:test_ros2_client_cpp>")
   set(TEST_BRIDGE_ROS2_SERVER "$<TARGET_FILE:test_ros2_server_cpp>")
-  set(TEST_BRIDGE_RMW ${rmw_implementation})
 endif()
 
 macro(targets)
+  set(TEST_BRIDGE_RMW ${rmw_implementation})
+
   configure_file(
     test/test_topics_across_dynamic_bridge.py.in
     test_topics_across_dynamic_bridge${target_suffix}.py.genexp
@@ -231,7 +232,7 @@ macro(targets)
   add_launch_test(
     "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
     TARGET test_topics_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTAION=${rmw_implementaion}
+    ENV RMW_IMPLEMENTATION=${rmw_implementation}
     TIMEOUT 60)
 
   configure_file(
@@ -246,7 +247,7 @@ macro(targets)
   add_launch_test(
     "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
     TARGET test_services_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTAION=${rmw_implementaion}
+    ENV RMW_IMPLEMENTATION=${rmw_implementation}
     TIMEOUT 60)
 endmacro()
 

--- a/test/test_topics_across_dynamic_bridge.py.in
+++ b/test/test_topics_across_dynamic_bridge.py.in
@@ -57,9 +57,14 @@ def generate_test_description(test_name, talker_cmd, listener_cmd, ready_fn):
     ))
 
     # dynamic bridge
+    bridge_cmd = [TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE]
+    # TODO(hidmic): re-enable rosout logging when Fast-RTPS supports registering multiple
+    #               typesupports for the same topic in the same process.
+    #               See https://github.com/ros2/rmw_fastrtps/issues/265.
+    if 'fastrtps' in TEST_BRIDGE_RMW:
+        bridge_cmd.append('__log_disable_rosout:=true')
     rosbridge_process = ExecuteProcess(
-        cmd=[TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_DYNAMIC_BRIDGE],
-        name=test_name + '__dynamic_bridge',
+        cmd=bridge_cmd, name=test_name + '__dynamic_bridge',
     )
     launch_description.add_action(rosbridge_process)
 


### PR DESCRIPTION
Closes https://github.com/ros2/build_cop/issues/192 (again). Incidentally, I came across some typos in the CMakeLists.txt affecting the tests (!) that got past review/CI before. Those are fixed in their own separate commit.


* CI packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=212)](http://ci.ros2.org/job/ci_packaging_linux/212/)