### PR TITLE
Disable rosout logging for the bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,10 +215,11 @@ if(TEST_ROS1_BRIDGE)
   set(TEST_BRIDGE_DYNAMIC_BRIDGE "$<TARGET_FILE:dynamic_bridge>")
   set(TEST_BRIDGE_ROS2_CLIENT "$<TARGET_FILE:test_ros2_client_cpp>")
   set(TEST_BRIDGE_ROS2_SERVER "$<TARGET_FILE:test_ros2_server_cpp>")
-  set(TEST_BRIDGE_RMW ${rmw_implementation})
 endif()
 
 macro(targets)
+  set(TEST_BRIDGE_RMW ${rmw_implementation})
+
   configure_file(
     test/test_topics_across_dynamic_bridge.py.in
     test_topics_across_dynamic_bridge${target_suffix}.py.genexp
@@ -231,7 +232,7 @@ macro(targets)
   add_launch_test(
     "${CMAKE_CURRENT_BINARY_DIR}/test_topics_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
     TARGET test_topics_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTAION=${rmw_implementaion}
+    ENV RMW_IMPLEMENTATION=${rmw_implementation}
     TIMEOUT 60)
 
   configure_file(
@@ -246,7 +247,7 @@ macro(targets)
   add_launch_test(
     "${CMAKE_CURRENT_BINARY_DIR}/test_services_across_dynamic_bridge${target_suffix}_$<CONFIG>.py"
     TARGET test_services_across_dynamic_bridge${target_suffix}
-    ENV RMW_IMPLEMENTAION=${rmw_implementaion}
+    ENV RMW_IMPLEMENTATION=${rmw_implementation}
     TIMEOUT 60)
 endmacro()
 

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstring>
 #include <map>
 #include <memory>
 #include <set>
@@ -35,6 +36,8 @@
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/scope_exit.hpp"
+
+#include "rcutils/get_env.h"
 
 #include "ros1_bridge/bridge.hpp"
 
@@ -456,7 +459,23 @@ int main(int argc, char * argv[])
   }
 
   // ROS 2 node
-  rclcpp::init(argc, argv);
+
+  // TODO(hidmic): remove when Fast-RTPS supports registering multiple
+  //               typesupports for the same topic in the same process.
+  //               See https://github.com/ros2/rmw_fastrtps/issues/265.
+  std::vector<char *> args(argv, argv + argc);
+  char log_disable_rosout[] = "__log_disable_rosout:=true";
+
+  const char * rmw_implementation = "";
+  const char * error = rcutils_get_env("RMW_IMPLEMENTATION", &rmw_implementation);
+  if (NULL != error) {
+    throw std::runtime_error(error);
+  }
+  if (0 == strcmp(rmw_implementation, "") || NULL != strstr(rmw_implementation, "fastrtps")) {
+    args.push_back(log_disable_rosout);
+  }
+  rclcpp::init(args.size(), args.data());
+
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
 
   // ROS 1 node


### PR DESCRIPTION
Closes https://github.com/ros2/build_cop/issues/192, by disabling rosout logging whenever the RMW implementation of choice is based on Fast-RTPS.

Additionally, some typos I found in the CMakeLists.txt affecting the tests (!) and got past review/CI before are fixed in their own separate commit.