### PR TITLE
add missing test dependency in Crystal

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
   <test_depend>demo_nodes_cpp</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
   <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>ros2run</test_depend>
 
   <group_depend>rosidl_interface_packages</group_depend>


### PR DESCRIPTION
Used here: https://github.com/ros2/ros1_bridge/blob/dad409c681ea78d2d7107e64ccac8e03842c23e3/test/test_dynamic_bridge.py.in#L21

Addresses the bridge related test failures: http://build.ros2.org/view/Cci/job/Cci__nightly_ubuntu_bionic_amd64/200/testReport/