### PR TITLE
Add note in documentation about rostopic echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you would like to use a bridge with other interfaces (including your own cust
 See [the documentation](doc/index.rst) for an example setup.
 
 For efficiency reasons, topics will only be bridged when matching publisher-subscriber pairs are active for a topic on either side of the bridge.
+Note that before `rostopic echo` would work with bridged topics, a subscriber must already exist, in order for `echo` to determine the message type and then to create its own subscriber.
 You can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 


### PR DESCRIPTION
Adding a clarification in documentation, because @clalancette and I think `rostopic echo` is an obvious first thing that everyone starting to use the bridge would try, that there should be solid documentation so that people have the correct expectation that they need an actual subscriber, not just `echo` and decide the bridge doesn't work for them, which we saw happen.