### PR TITLE
Use %zu print format for size_t

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -702,7 +702,7 @@ int main(int argc, char * argv[])
         }
 
         if (output_topic_introspection) {
-          printf("  ROS 2: %s (%s) [%ld pubs, %ld subs]\n",
+          printf("  ROS 2: %s (%s) [%zu pubs, %zu subs]\n",
             topic_name.c_str(), topic_type.c_str(), publisher_count, subscriber_count);
         }
       }


### PR DESCRIPTION
One more brick in the wall of https://github.com/ros2/ros2/issues/721

Fixes warnings seen here https://ci.ros2.org/job/ci_packaging_linux-armhf/4/warnings23Result/package.1964502061/