### PR TITLE
Clearer instructions for example ros1->ros2

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You will get errors from most tools if they have both workspaces in their enviro
 First we start a ROS 1 `roscore`:
 
 ```
-# Shell A:
+# Shell A (ROS 1 only):
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
@@ -120,11 +120,15 @@ Then we start the dynamic bridge which will watch the available ROS 1 and ROS 2 
 Once a *matching* topic has been detected it starts to bridge the messages on this topic.
 
 ```
-# Shell B:
+# Shell B (ROS 1 + ROS 2):
+# Source ROS 1 first:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
+# Source ROS 2 next:
 . <install-space-with-bridge>/setup.bash
+# For example:
+# . /opt/ros/dashing/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```


### PR DESCRIPTION
Related to #205. I also found the instructions unclear about which ROS versions one has to source to run the bridge, so the proposal is to make it clearer.