### PR TITLE
Update __log_rosout_disable workaround to use --ros-args.

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -463,8 +463,7 @@ int main(int argc, char * argv[])
   // TODO(hidmic): remove when Fast-RTPS supports registering multiple
   //               typesupports for the same topic in the same process.
   //               See https://github.com/ros2/rmw_fastrtps/issues/265.
-  std::vector<char *> args(argv, argv + argc);
-  char log_disable_rosout[] = "__log_disable_rosout:=true";
+  std::vector<const char *> args(argv, argv + argc);
 
   const char * rmw_implementation = "";
   const char * error = rcutils_get_env("RMW_IMPLEMENTATION", &rmw_implementation);
@@ -472,7 +471,8 @@ int main(int argc, char * argv[])
     throw std::runtime_error(error);
   }
   if (0 == strcmp(rmw_implementation, "") || NULL != strstr(rmw_implementation, "fastrtps")) {
-    args.push_back(log_disable_rosout);
+    args.push_back("--ros-args");
+    args.push_back("__log_disable_rosout:=true");
   }
   rclcpp::init(args.size(), args.data());
 


### PR DESCRIPTION
Closes https://github.com/ros2/build_cop/issues/229. Precisely what the title says. Our workaround (https://github.com/ros2/ros1_bridge/pull/197) for https://github.com/ros2/rmw_fastrtps/issues/265 got outdated after https://github.com/ros2/rcl/pull/477. I also took the opportunity to simplify the code a bit.


CI packaging Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=265)](http://ci.ros2.org/job/ci_packaging_linux/265/)