### PR TITLE
Promote special CLI rules to flags.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -249,4 +249,4 @@ Known Issues
 - ``/rosout`` logging, which maps from ``rosgraph_msgs/Log`` to ``rcl_interfaces/Log``, requires `field selection <https://github.com/ros2/ros1_bridge/pull/174>`_.
   This `works with OpenSplice and Connext <https://github.com/ros2/rcl_interfaces/pull/67>`_, but `not with Fast-RTPS <https://github.com/ros2/rcl_interfaces/issues/61>`_.
   For it to work with Fast-RTPS, `this bug <https://github.com/ros2/rmw_fastrtps/issues/265>`_ needs to be fixed.
-  As a workaround, run the subscriber with ``__log_disable_rosout:=true``.
+  As a workaround, run the subscriber with ``--disable-rosout-logs``.

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -472,7 +472,7 @@ int main(int argc, char * argv[])
   }
   if (0 == strcmp(rmw_implementation, "") || NULL != strstr(rmw_implementation, "fastrtps")) {
     args.push_back("--ros-args");
-    args.push_back("__log_disable_rosout:=true");
+    args.push_back("--disable-rosout-logs");
   }
   rclcpp::init(args.size(), args.data());
 


### PR DESCRIPTION
This pull requests adapts `ros1_bridge` to the changes introduced by https://github.com/ros2/rcl/pull/495.