### PR TITLE
Don't use launch_testing features that will be deprecated

### DIFF
--- a/test/test_services_across_dynamic_bridge.py.in
+++ b/test/test_services_across_dynamic_bridge.py.in
@@ -19,6 +19,7 @@ from launch.actions import ExecuteProcess
 from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 
 
 TEST_BRIDGE_ROS1_ENV = '@TEST_BRIDGE_ROS1_ENV@'
@@ -38,7 +39,7 @@ TEST_BRIDGE_ROS2_SERVER = '@TEST_BRIDGE_ROS2_SERVER@'
      [TEST_BRIDGE_ROS2_SERVER],
      [TEST_BRIDGE_ROS1_ENV, TEST_BRIDGE_ROS1_CLIENT]),
 ])
-def generate_test_description(test_name, server_cmd, client_cmd, ready_fn):
+def generate_test_description(test_name, server_cmd, client_cmd):
     launch_description = LaunchDescription()
 
     # ROS 1 core
@@ -65,15 +66,17 @@ def generate_test_description(test_name, server_cmd, client_cmd, ready_fn):
     launch_description.add_action(client_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 
 
 class TestServicesAcrossDynamicBridge(unittest.TestCase):
-    def test_client_process_terminates_after_a_finite_amount_of_time(self, client_process):
+    def test_client_process_terminates_after_a_finite_amount_of_time(self,
+                                                                     client_process,
+                                                                     proc_info):
         """Test that the client executables terminates after a finite amount of time."""
-        self.proc_info.assertWaitForShutdown(process=client_process, timeout=30)
+        proc_info.assertWaitForShutdown(process=client_process, timeout=30)
 
 
 @launch_testing.post_shutdown_test()

--- a/test/test_topics_across_dynamic_bridge.py.in
+++ b/test/test_topics_across_dynamic_bridge.py.in
@@ -22,6 +22,7 @@ from launch.actions import ExecuteProcess
 from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing_ros
 
 from ros2run.api import get_executable_path
@@ -47,7 +48,7 @@ TEST_BRIDGE_RMW = '@TEST_BRIDGE_RMW@'
      [TEST_BRIDGE_ROS2_TALKER],
      [TEST_BRIDGE_ROS1_ENV] + TEST_BRIDGE_ROS1_LISTENER),
 ])
-def generate_test_description(test_name, talker_cmd, listener_cmd, ready_fn):
+def generate_test_description(test_name, talker_cmd, listener_cmd):
     launch_description = LaunchDescription()
 
     # ROS 1 core
@@ -76,7 +77,7 @@ def generate_test_description(test_name, talker_cmd, listener_cmd, ready_fn):
     launch_description.add_action(listener_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 


### PR DESCRIPTION
Removing some of the 'magic' features from launch_testing that we want to deprecate.

For background, see ros2/launch#346

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>