### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -392,9 +392,10 @@ void get_ros1_service_info(
     return;
   }
   ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
-  auto transport_exit = rclcpp::make_scope_exit([transport]() {
-        transport->close();
-      });
+  auto transport_exit = rclcpp::make_scope_exit(
+    [transport]() {
+      transport->close();
+    });
   if (!transport->connect(host, port)) {
     fprintf(stderr, "Failed to connect to %s:%d\n", host.data(), port);
     return;
@@ -588,7 +589,8 @@ int main(int argc, char * argv[])
           current_ros1_subscribers[topic_name] = topic.datatype;
         }
         if (output_topic_introspection) {
-          printf("  ROS 1: %s (%s) [%s pubs, %s subs]\n",
+          printf(
+            "  ROS 1: %s (%s) [%s pubs, %s subs]\n",
             topic_name.c_str(), topic.datatype.c_str(),
             has_publisher ? ">0" : "0", has_subscriber ? ">0" : "0");
         }
@@ -702,7 +704,8 @@ int main(int argc, char * argv[])
         }
 
         if (output_topic_introspection) {
-          printf("  ROS 2: %s (%s) [%zu pubs, %zu subs]\n",
+          printf(
+            "  ROS 2: %s (%s) [%zu pubs, %zu subs]\n",
             topic_name.c_str(), topic_type.c_str(), publisher_count, subscriber_count);
         }
       }

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -119,7 +119,8 @@ int main(int argc, char * argv[])
         "ros2", package_name, type_name);
       if (factory) {
         try {
-          service_bridges_1_to_2.push_back(factory->service_bridge_1_to_2(
+          service_bridges_1_to_2.push_back(
+            factory->service_bridge_1_to_2(
               ros1_node, ros2_node, service_name));
           printf("Created 1 to 2 bridge for service %s\n", service_name.c_str());
         } catch (std::runtime_error & e) {


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux&build=1747)](https://ci.ros2.org/view/packaging/job/packaging_linux/1747/) (7 test failures)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=289)](https://ci.ros2.org/job/ci_packaging_linux/289/) (3 remaining / unrelated test failures)