### PR TITLE
Ignore actionlib_msgs deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,17 +90,11 @@ list(APPEND generated_files "${generated_path}/get_mappings.cpp")
 
 # generate per interface compilation units to keep the memory usage low
 ament_index_get_resources(ros2_interface_packages "rosidl_interfaces")
+# actionlib_msgs is deprecated, but we will quiet the warning until the bridge has support for
+# ROS actions: https://github.com/ros2/design/issues/195
+set(actionlib_msgs_DEPRECATED_QUIET TRUE)
 foreach(package_name ${ros2_interface_packages})
-  # actionlib_msgs is deprecated, but we will quiet the warning until the bridge has support for ROS actions
-  # https://github.com/ros2/design/issues/195
-  if("${package_name}" STREQUAL "actionlib_msgs")
-    set(_cache_cmake_warn_deprecated ${CMAKE_WARN_DEPRECATED})
-    set(CMAKE_WARN_DEPRECATED FALSE)
-  endif()
   find_package(${package_name} QUIET REQUIRED)
-  if("${package_name}" STREQUAL "actionlib_msgs")
-    set(CMAKE_WARN_DEPRECATED ${_cache_cmake_warn_deprecated})
-  endif()
   message(STATUS "Found ${package_name}: ${${package_name}_VERSION} (${${package_name}_DIR})")
   if(NOT "${package_name}" STREQUAL "builtin_interfaces")
     list(APPEND generated_files "${generated_path}/${package_name}_factories.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,16 @@ list(APPEND generated_files "${generated_path}/get_mappings.cpp")
 # generate per interface compilation units to keep the memory usage low
 ament_index_get_resources(ros2_interface_packages "rosidl_interfaces")
 foreach(package_name ${ros2_interface_packages})
+  # actionlib_msgs is deprecated, but we will quiet the warning until the bridge has support for ROS actions
+  # https://github.com/ros2/design/issues/195
+  if("${package_name}" STREQUAL "actionlib_msgs")
+    set(_cache_cmake_warn_deprecated ${CMAKE_WARN_DEPRECATED})
+    set(CMAKE_WARN_DEPRECATED FALSE)
+  endif()
   find_package(${package_name} QUIET REQUIRED)
+  if("${package_name}" STREQUAL "actionlib_msgs")
+    set(CMAKE_WARN_DEPRECATED ${_cache_cmake_warn_deprecated})
+  endif()
   message(STATUS "Found ${package_name}: ${${package_name}_VERSION} (${${package_name}_DIR})")
   if(NOT "${package_name}" STREQUAL "builtin_interfaces")
     list(APPEND generated_files "${generated_path}/${package_name}_factories.cpp")


### PR DESCRIPTION
Fixes https://github.com/ros2/build_farmer/issues/267
Depends on https://github.com/ament/ament_cmake/pull/223

Note, this change will ignore *all* deprecation warnings produced by calling `find_package(actionlib_msgs)`. I'm not sure of a nice way in CMake to ignore a single message coming from a command, but I think this solution is reasonable since I don't expect other deprecation warnings to come from finding `actionlib_msgs`. Alternatively, we could introduce a new variable in `ament_cmake` to toggle the deprecation warning, e.g. `actionlib_msgs_IGNORE_DEPRECATED`, but it doesn't seem very elegant.