### PR TITLE
👩‍🌾 [Proposal] No warning for missing ROS 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
-  message(WARNING "Failed to find ROS 1 roscpp, skipping...")
+  message(STATUS "Failed to find ROS 1 roscpp, skipping...")
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package(
     CONFIG_EXTRAS ${cmake_extras_files}


### PR DESCRIPTION
This warning keeps coming up on [ROS 2's CI](http://build.ros2.org/view/Fci/job/Fci__nightly-release_ubuntu_focal_amd64/44/warnings2Result/), but if it's not something that needs to be fixed, I'd propose to turn into an informational message instead of a warning (which prompts action).

I'm not sure if this has been discussed in the past, and I can see an argument for keeping it as it is. I was just wondering what people thought.