### PR TITLE
[parameter_bridge] add srv to the type to keep yaml description consistent

### DIFF
--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -109,7 +109,7 @@ int main(int argc, char * argv[])
     for (size_t i = 0; i < static_cast<size_t>(services_1_to_2.size()); ++i) {
       std::string service_name = static_cast<std::string>(services_1_to_2[i]["service"]);
       std::string package_name = static_cast<std::string>(services_1_to_2[i]["package"]);
-      std::string type_name = static_cast<std::string>(services_1_to_2[i]["type"]);
+      std::string type_name = "srv/" + static_cast<std::string>(services_1_to_2[i]["type"]);
       printf(
         "Trying to create bridge for ROS 2 service '%s' "
         "with package '%s' and type '%s'\n",


### PR DESCRIPTION
Similar to https://github.com/ros2/ros1_bridge/pull/194

Before this PR the syntax for bridging services in both directions was the following:
<details>

```yaml
---
# service requests going from 2 to 1
# server on ROS1 side, client on ROS2 side
services_2_to_1:
  -
    service: /add_two_ints
    package: roscpp_tutorials
    type: TwoInts
# service requests going from 1 to 2
# server on ROS2 side, client on ROS1 side
services_1_to_2:
  -
    service: /add_two_ints
    package: example_interfaces
    type: srv/AddTwoInts
```

</details>

Having to specify the type as `srv/AddTwoInts` seems uncommon and counter intuitive

<details><summary>After this PR</summary>

```yaml
---
# service requests going from 2 to 1
# server on ROS1 side, client on ROS2 side
services_2_to_1:
  -
    service: /add_two_ints
    package: roscpp_tutorials
    type: TwoInts
# service requests going from 1 to 2
# server on ROS2 side, client on ROS1 side
services_1_to_2:
  -
    service: /add_two_ints
    package: example_interfaces
    type: AddTwoInts
```

</details>

---

This is still breaking pattern from what is used to specify topic bridging:

```yaml
topics: 
  -
    topic: /clock
    type: rosgraph_msgs/msg/Clock
```

Not sure what the reason was in the first place for splitting the package and the type name only for services, but this PR keeps that behavior.