### PR TITLE
enhance parameter bridge enable options for topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Note that before `rostopic echo` would work with bridged topics, a subscriber mu
 You can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
-If you want to specify messages/services you want to bridge, run `ros2 run ros1_bridge parameter_bridge`. See [here](doc/parameter_bridge.rst) for more information.
+If you want to specify messages/services you want to bridge, run `ros2 run ros1_bridge parameter_bridge`.
+See [here](doc/parameter_bridge.rst) for more information.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note that before `rostopic echo` would work with bridged topics, a subscriber mu
 You can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
-If you want to specify topics you want to bridge, run `ros2 run ros1_bridge parameter_bridge`. See [here](doc/parameter_bridge.rst) for more information.
+If you want to specify messages/services you want to bridge, run `ros2 run ros1_bridge parameter_bridge`. See [here](doc/parameter_bridge.rst) for more information.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Note that before `rostopic echo` would work with bridged topics, a subscriber mu
 You can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
+If you want to specify topics you want to bridge, run `ros2 run ros1_bridge parameter_bridge`. See [here](doc/parameter_bridge.rst) for more information.
+
 ## Prerequisites
 
 In order to run the bridge you need to either:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,4 @@
+.. _index:
 ros1_bridge
 ===========
 

--- a/doc/parameter_bridge.rst
+++ b/doc/parameter_bridge.rst
@@ -1,0 +1,67 @@
+parameter_bridge configuration
+==============================
+
+You can launch parameter_bridge with the following command::
+  
+    ros2 run ros1_bridge parameter_bridge
+
+Parameter bridge reads ``/topics`` parameter on ROS1 to make your bridge. Here is an example of configuration::
+
+ <rosparam>
+ topics:
+   -
+     topic: /clock
+     type: rosgraph_msgs/msg/Clock
+     queue_size: 100
+     direction: 1to2
+   -
+     topic: /tf
+     type: tf2_msgs/msg/TFMessage
+     queue_size: 10
+     direction: bidirectional
+     reliable: true
+   -
+     topic: /tf_static
+     type: tf2_msgs/msg/TFMessage
+     queue_size: 10
+     direction: 1to2
+     transient_local: true
+     reliable: true
+   -
+     topic: /scan
+     type: sensor_msgs/msg/LaserScan
+     queue_size: 10
+     direction: 1to2
+   -
+     topic: /cmd_vel
+     type: geometry_msgs/msg/Twist
+     queue_size: 10
+     direction: 2to1
+   -
+     topic: /map
+     type: nav_msgs/msg/OccupancyGrid
+     queue_size: 1
+     direction: 2to1
+     transient_local: true
+     reliable: true
+     latch: true
+ </rosparam>
+
+Configuration Syntax
+--------------------
+
+- **topics**: <array of **topic**>
+- **topic**: <dict>
+
+  .. csv-table:: 
+   :header: "key", "required", "default", "description"
+   :widths: 20, 10, 10, 50
+
+   **topic_name**, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
+   **type**,       YES, N/A, message type in ROS2 (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
+   **queue_size**, NO,  100, queue size used in both ROS1/2 
+   **direction**,  NO,  bidirectionl, ``bidirectional`` or ``1to2`` or ``2to1``
+   **transient_local**, NO, false, set ROS2 QoS durability profile transient_local (used both for 1to2 and 2to1)
+   **reliable**,        NO, false, set ROS2 QoS durability profile reliable (used both for 1to2 and 2to1)
+   **latch**,           NO, false, publish ROS1 message with latch option (used only for 2to1)
+  

--- a/doc/parameter_bridge.rst
+++ b/doc/parameter_bridge.rst
@@ -6,7 +6,9 @@ You can launch parameter_bridge with the following command::
   
     ros2 run ros1_bridge parameter_bridge [<topics_name> [<services_1_to_2_name> [<services_2_to_1_name>]]]
 
-Parameter bridge reads ``topics``, ``services_1_to_2``, and ``services_2_to_1`` parameters on ROS1 as default to make your bridge. You can specify the names of those parameters as arguments of the command. Here is an example of configuration::
+Parameter bridge reads ``topics``, ``services_1_to_2``, and ``services_2_to_1`` parameters on ROS1 as default to make your bridge.
+You can specify the names of those parameters as arguments of the command.
+Here is an example of configuration::
 
  <rosparam>
  topics:

--- a/doc/parameter_bridge.rst
+++ b/doc/parameter_bridge.rst
@@ -57,7 +57,7 @@ Configuration Syntax
    :header: "key", "required", "default", "description"
    :widths: 20, 10, 10, 50
 
-   **topic_name**, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
+   **topic**, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
    **type**,       YES, N/A, message type in ROS2 (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
    **queue_size**, NO,  100, queue size used in both ROS1/2 
    **direction**,  NO,  bidirectionl, ``bidirectional`` or ``1to2`` or ``2to1``

--- a/doc/parameter_bridge.rst
+++ b/doc/parameter_bridge.rst
@@ -63,27 +63,30 @@ Here is an example of configuration::
 Configuration Syntax
 --------------------
 
-- **topics**: <array of **topic**>
-- **topic**: <dict>
+- ``topics``: <array of *topic*>
+
+  - *topic*: <dict>
 
   .. csv-table:: 
    :header: "key", "required", "default", "description"
    :widths: 20, 10, 10, 50
 
-   **topic**, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
-   **type**,       YES, N/A, Message type in ROS2 (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
-   **queue_size**, NO,  100, Queue size used in both ROS1/2 
-   **direction**,  NO,  bidirectionl, ``bidirectional`` or ``1to2`` or ``2to1``
-   **transient_local**, NO, false, Set ROS2 QoS durability profile transient_local (used both for 1to2 and 2to1)
-   **reliable**,        NO, false, Set ROS2 QoS durability profile reliable (used both for 1to2 and 2to1)
-   **latch**,           NO, false, Publish ROS1 message with latch option (used only for 2to1)
-- **services_1_to_2**: <array of **service**>, ROS1 services will be available in ROS2
-- **services_2_to_1**: <array of **service**>, ROS2 services will be available in ROS1
-- **service**: <dict>
+   ``topic``, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
+   ``type``,       YES, N/A, Message type in ROS2 (see `here <./index.rst#how-are-ros-1-and-2-messages-associated-with-each-other>`_ how to map ROS1 and ROS2 messages)
+   ``queue_size``, NO,  100, Queue size used in both ROS1/2
+   ``direction``,  NO,  bidirectionl, ``bidirectional`` or ``1to2`` or ``2to1``
+   ``transient_local``, NO, false, Set ROS2 QoS durability profile transient_local (used both for 1to2 and 2to1)
+   ``reliable``,        NO, false, Set ROS2 QoS durability profile reliable (used both for 1to2 and 2to1)
+   ``latch``,           NO, false, Publish ROS1 message with latch option (used only for 2to1)
+
+- ``services_1_to_2``: <array of *service*>, ROS1 services will be available in ROS2
+- ``services_2_to_1``: <array of *service*>, ROS2 services will be available in ROS1
+
+  - *service*: <dict>
 
   .. csv-table:: 
    :header: "key", "required", "description"
    :widths: 20, 10, 60
 
-   **service**, YES, Name of the service to bridge which is used in both ROS1/2
-   **type**, YES, Service type in ROS2  (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
+   ``service``, YES, Name of the service to bridge which is used in both ROS1/2
+   ``type``, YES, Service type in ROS2  (see `here <./index.rst#how-are-ros-1-and-2-services-associated-with-each-other>`_ how to map ROS1 and ROS2 services)

--- a/doc/parameter_bridge.rst
+++ b/doc/parameter_bridge.rst
@@ -1,11 +1,12 @@
+
 parameter_bridge configuration
 ==============================
 
 You can launch parameter_bridge with the following command::
   
-    ros2 run ros1_bridge parameter_bridge
+    ros2 run ros1_bridge parameter_bridge [<topics_name> [<services_1_to_2_name> [<services_2_to_1_name>]]]
 
-Parameter bridge reads ``/topics`` parameter on ROS1 to make your bridge. Here is an example of configuration::
+Parameter bridge reads ``topics``, ``services_1_to_2``, and ``services_2_to_1`` parameters on ROS1 as default to make your bridge. You can specify the names of those parameters as arguments of the command. Here is an example of configuration::
 
  <rosparam>
  topics:
@@ -45,6 +46,16 @@ Parameter bridge reads ``/topics`` parameter on ROS1 to make your bridge. Here i
      transient_local: true
      reliable: true
      latch: true
+
+ services_1_to_2:
+   -
+     service: /gazebo/pause_physics
+     type: std_srvs/srv/Empty
+
+ services_2_to_1:
+   -
+     service: /reinitialize_global_localization
+     type: std_srvs/srv/Empty
  </rosparam>
 
 Configuration Syntax
@@ -58,10 +69,19 @@ Configuration Syntax
    :widths: 20, 10, 10, 50
 
    **topic**, YES, N/A, Name of the topic to bridge which is used in both ROS1/2
-   **type**,       YES, N/A, message type in ROS2 (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
-   **queue_size**, NO,  100, queue size used in both ROS1/2 
+   **type**,       YES, N/A, Message type in ROS2 (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)
+   **queue_size**, NO,  100, Queue size used in both ROS1/2 
    **direction**,  NO,  bidirectionl, ``bidirectional`` or ``1to2`` or ``2to1``
-   **transient_local**, NO, false, set ROS2 QoS durability profile transient_local (used both for 1to2 and 2to1)
-   **reliable**,        NO, false, set ROS2 QoS durability profile reliable (used both for 1to2 and 2to1)
-   **latch**,           NO, false, publish ROS1 message with latch option (used only for 2to1)
-  
+   **transient_local**, NO, false, Set ROS2 QoS durability profile transient_local (used both for 1to2 and 2to1)
+   **reliable**,        NO, false, Set ROS2 QoS durability profile reliable (used both for 1to2 and 2to1)
+   **latch**,           NO, false, Publish ROS1 message with latch option (used only for 2to1)
+- **services_1_to_2**: <array of **service**>, ROS1 services will be available in ROS2
+- **services_2_to_1**: <array of **service**>, ROS2 services will be available in ROS1
+- **service**: <dict>
+
+  .. csv-table:: 
+   :header: "key", "required", "description"
+   :widths: 20, 10, 60
+
+   **service**, YES, Name of the service to bridge which is used in both ROS1/2
+   **type**, YES, Service type in ROS2  (see `here <./index.rst>`_ how to map ROS1 and ROS2 messages)

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -72,6 +72,9 @@ get_factory(
 std::unique_ptr<ServiceFactoryInterface>
 get_service_factory(const std::string &, const std::string &, const std::string &);
 
+rmw_qos_profile_t
+get_qos(size_t queue_size, bool transient_local, bool reliable);
+
 Bridge1to2Handles
 create_bridge_from_1_to_2(
   ros::NodeHandle ros1_node,
@@ -81,7 +84,9 @@ create_bridge_from_1_to_2(
   size_t subscriber_queue_size,
   const std::string & ros2_type_name,
   const std::string & ros2_topic_name,
-  size_t publisher_queue_size);
+  size_t publisher_queue_size,
+  bool transient_local = false,
+  bool reliable = false);
 
 Bridge2to1Handles
 create_bridge_from_2_to_1(
@@ -93,7 +98,10 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
-  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
+  rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr,
+  bool transient_local = false,
+  bool reliable = false,
+  bool latch = false);
 
 BridgeHandles
 create_bidirectional_bridge(
@@ -102,7 +110,10 @@ create_bidirectional_bridge(
   const std::string & ros1_type_name,
   const std::string & ros2_type_name,
   const std::string & topic_name,
-  size_t queue_size = 10);
+  size_t queue_size = 10,
+  bool transient_local = false,
+  bool reliable = false,
+  bool latch = false);
 
 }  // namespace ros1_bridge
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -20,14 +20,18 @@
 namespace ros1_bridge
 {
 rmw_qos_profile_t
-get_qos(size_t queue_size, bool transient_local, bool reliable) {
-    auto qos = rclcpp::QoS(rclcpp::KeepLast(queue_size)) ;
+get_qos(
+  size_t queue_size,
+  bool transient_local,
+  bool reliable)
+{
+  auto qos = rclcpp::QoS(rclcpp::KeepLast(queue_size));
 
-    if (transient_local) { qos.transient_local(); }
-    if (reliable) { qos.reliable(); }
+  if (transient_local) {qos.transient_local();}
+  if (reliable) {qos.reliable();}
 
-    return qos.get_rmw_qos_profile();
-  }
+  return qos.get_rmw_qos_profile();
+}
 
 Bridge1to2Handles
 create_bridge_from_1_to_2(
@@ -101,7 +105,8 @@ create_bidirectional_bridge(
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,
-    ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, queue_size, transient_local, reliable);
+    ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, queue_size,
+    transient_local, reliable);
   handles.bridge2to1 = create_bridge_from_2_to_1(
     ros2_node, ros1_node,
     ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -84,48 +84,45 @@ int main(int argc, char * argv[])
       bool transient_local = static_cast<bool>(topics[i]["transient_local"]);
       bool reliable = static_cast<bool>(topics[i]["reliable"]);
       bool latch = static_cast<bool>(topics[i]["latch"]);
-      
+
       if (!queue_size) {
         queue_size = 100;
       }
       if (direction == "") {
-	direction = "bidirectional";
+        direction = "bidirectional";
       }
-      
+
       printf(
-	"Trying to create %s bridge for topic '%s' "
-	"with ROS 2 type '%s' (transient_local=%s reliable=%s latch=%s)\n",
-	direction.c_str(), topic_name.c_str(), type_name.c_str(),
-	transient_local?"true":"false", reliable?"true":"false", latch?"true":"false");
+        "Trying to create %s bridge for topic '%s' "
+        "with ROS 2 type '%s' (transient_local=%s reliable=%s latch=%s)\n",
+        direction.c_str(), topic_name.c_str(), type_name.c_str(),
+        transient_local ? "true" : "false", reliable ? "true" : "false", latch ? "true" : "false");
 
       try {
-
-	if (direction == "bidirectional") {
-	  ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-	    ros1_node, ros2_node, "", type_name, topic_name, queue_size, transient_local, reliable, latch);
-	  all_handles.push_back(handles);
-	}
-	else if (direction == "1to2") {
-	  ros1_bridge::Bridge1to2Handles handles = ros1_bridge::create_bridge_from_1_to_2(
-	    ros1_node, ros2_node, "", topic_name, queue_size, type_name, topic_name, queue_size,
-	    transient_local, reliable);
-	  all_1to2_handles.push_back(handles);
-	}
-	else if (direction == "2to1") {
-	  ros1_bridge::Bridge2to1Handles handles = ros1_bridge::create_bridge_from_2_to_1(
-	    ros2_node, ros1_node, type_name, topic_name, queue_size, "", topic_name, queue_size,
-	    nullptr, transient_local, reliable, latch);
-	  all_2to1_handles.push_back(handles);
-	}
-	
+        if (direction == "bidirectional") {
+          ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
+            ros1_node, ros2_node, "", type_name, topic_name, queue_size, transient_local,
+            reliable, latch);
+          all_handles.push_back(handles);
+        } else if (direction == "1to2") {
+          ros1_bridge::Bridge1to2Handles handles = ros1_bridge::create_bridge_from_1_to_2(
+            ros1_node, ros2_node, "", topic_name, queue_size, type_name, topic_name, queue_size,
+            transient_local, reliable);
+          all_1to2_handles.push_back(handles);
+        } else if (direction == "2to1") {
+          ros1_bridge::Bridge2to1Handles handles = ros1_bridge::create_bridge_from_2_to_1(
+            ros2_node, ros1_node, type_name, topic_name, queue_size, "", topic_name, queue_size,
+            nullptr, transient_local, reliable, latch);
+          all_2to1_handles.push_back(handles);
+        }
       } catch (std::runtime_error & e) {
-	
-	fprintf(
-	  stderr,
-	  "failed to create %s bridge for topic '%s' "
-	  "with ROS 2 type '%s' (transient_local=%s reliable=%s latch=%s): %s\n",
-	  direction.c_str(), topic_name.c_str(), type_name.c_str(),
-	  transient_local?"true":"false", reliable?"true":"false", latch?"true":"false", e.what());
+        fprintf(
+          stderr,
+          "failed to create %s bridge for topic '%s' "
+          "with ROS 2 type '%s' (transient_local=%s reliable=%s latch=%s): %s\n",
+          direction.c_str(), topic_name.c_str(), type_name.c_str(),
+          transient_local ? "true" : "false", reliable ? "true" : "false", latch ? "true" : "false",
+          e.what());
       }
     }
   } else {


### PR DESCRIPTION
This enhancement enables parameter_bridge to control the bridge precisely with the following keys. Please see the detail in doc/parameter_bridge.rst

 - direction
 - transient_local
 - reliable
 - latch

I was struggling with tf_static which is a latched topic in ROS1 but cannot be seen in ROS2.
With specifying transient_local and reliable to true, it can be seen in ROS2 like a latched topic (of course need to use transient_local and reliable for the subscriber).

Signed-off-by: Daisuke Sato <daisukes@cmu.edu>