### PR TITLE
Do not generate files for interfaces in rmw_dds_common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ list(APPEND generated_files "${generated_path}/get_mappings.cpp")
 
 # generate per interface compilation units to keep the memory usage low
 ament_index_get_resources(ros2_interface_packages "rosidl_interfaces")
+# Do not generate factories for interfaces in rmw_dds_common
+list(REMOVE_ITEM ros2_interface_packages rmw_dds_common)
+
 # actionlib_msgs is deprecated, but we will quiet the warning until the bridge has support for
 # ROS actions: https://github.com/ros2/design/issues/195
 set(actionlib_msgs_DEPRECATED_QUIET TRUE)

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -252,6 +252,9 @@ def get_ros2_messages():
     # get messages from packages
     resource_type = 'rosidl_interfaces'
     resources = ament_index_python.get_resources(resource_type)
+    # Do not include messages in rmw_dds_common
+    del resources['rmw_dds_common']
+
     for package_name, prefix_path in resources.items():
         pkgs.append(package_name)
         resource, _ = ament_index_python.get_resource(resource_type, package_name)
@@ -305,6 +308,9 @@ def get_ros2_services():
     rules = []
     resource_type = 'rosidl_interfaces'
     resources = ament_index_python.get_resources(resource_type)
+    # Do not include messages in rmw_dds_common
+    del resources['rmw_dds_common']
+
     for package_name, prefix_path in resources.items():
         pkgs.append(package_name)
         resource, _ = ament_index_python.get_resource(resource_type, package_name)


### PR DESCRIPTION
Fixes https://github.com/ros2/rmw_dds_common/issues/8.

There's no reason to generate files for the interfaces in `rmw_dds_common`, so I propose to skip them.

Another way to skip the package, is to [avoid registering it](https://github.com/ros2/rosidl/blob/4d837670d5758a3d45b8c86f3d867f44edd1c221/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake#L252) as a `rosidl_interfaces` resource.
I can add an argument to [rosidl_generate_interfaces](https://github.com/ros2/rosidl/blob/4d837670d5758a3d45b8c86f3d867f44edd1c221/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake#L53) to do that.