### PR TITLE
deprecate package key for service parameters, use full type instead

### DIFF
--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -129,7 +129,7 @@ int main(int argc, char * argv[])
         "Trying to create bridge for ROS 2 service '%s' with type '%s'\n",
         service_name.c_str(), type_name.c_str());
 
-      size_t index = type_name.find("/");
+      const size_t index = type_name.find("/");
       if (index == std::string::npos) {
         fprintf(
           stderr,
@@ -191,7 +191,7 @@ int main(int argc, char * argv[])
         "Trying to create bridge for ROS 1 service '%s' with type '%s'\n",
         service_name.c_str(), type_name.c_str());
 
-      size_t index = type_name.find("/");
+      const size_t index = type_name.find("/");
       if (index == std::string::npos) {
         fprintf(
           stderr,

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -46,12 +46,16 @@ int main(int argc, char * argv[])
   std::list<ros1_bridge::ServiceBridge2to1> service_bridges_2_to_1;
 
   // bridge all topics listed in a ROS 1 parameter
-  // the parameter needs to be an array
+  // the topics parameter needs to be an array
   // and each item needs to be a dictionary with the following keys;
-  // topic: the name of the topic to bridge
-  // type: the type of the topic to bridge
+  // topic: the name of the topic to bridge (e.g. '/topic_name')
+  // type: the type of the topic to bridge (e.g. 'pkgname/msg/MsgName')
   // queue_size: the queue size to use (default: 100)
   const char * topics_parameter_name = "topics";
+  // the services parameters need to be arrays
+  // and each item needs to be a dictionary with the following keys;
+  // topic: the name of the topic to bridge (e.g. '/service_name')
+  // type: the type of the topic to bridge (e.g. 'pkgname/srv/SrvName')
   const char * services_1_to_2_parameter_name = "services_1_to_2";
   const char * services_2_to_1_parameter_name = "services_2_to_1";
   if (argc > 1) {
@@ -108,15 +112,33 @@ int main(int argc, char * argv[])
   {
     for (size_t i = 0; i < static_cast<size_t>(services_1_to_2.size()); ++i) {
       std::string service_name = static_cast<std::string>(services_1_to_2[i]["service"]);
-      std::string package_name = static_cast<std::string>(services_1_to_2[i]["package"]);
       std::string type_name = static_cast<std::string>(services_1_to_2[i]["type"]);
+      {
+        // for backward compatibility
+        std::string package_name = static_cast<std::string>(services_1_to_2[i]["package"]);
+        if (!package_name.empty()) {
+          fprintf(
+            stderr,
+            "The service '%s' uses the key 'package' which is deprecated for "
+            "services. Instead prepend the 'type' value with '<package>/'.\n",
+            service_name.c_str());
+          type_name = package_name + "/" + type_name;
+        }
+      }
       printf(
-        "Trying to create bridge for ROS 2 service '%s' "
-        "with package '%s' and type '%s'\n",
-        service_name.c_str(), package_name.c_str(), type_name.c_str());
+        "Trying to create bridge for ROS 2 service '%s' with type '%s'\n",
+        service_name.c_str(), type_name.c_str());
 
+      size_t index = type_name.find("/");
+      if (index == std::string::npos) {
+        fprintf(
+          stderr,
+          "the service '%s' has a type '%s' without a slash.\n",
+          service_name.c_str(), type_name.c_str());
+        continue;
+      }
       auto factory = ros1_bridge::get_service_factory(
-        "ros2", package_name, type_name);
+        "ros2", type_name.substr(0, index), type_name.substr(index + 1));
       if (factory) {
         try {
           service_bridges_1_to_2.push_back(
@@ -126,16 +148,14 @@ int main(int argc, char * argv[])
         } catch (std::runtime_error & e) {
           fprintf(
             stderr,
-            "failed to create bridge ROS 1 service '%s' "
-            "with package '%s' and type '%s': %s\n",
-            service_name.c_str(), type_name.c_str(), type_name.c_str(), e.what());
+            "failed to create bridge ROS 1 service '%s' with type '%s': %s\n",
+            service_name.c_str(), type_name.c_str(), e.what());
         }
       } else {
         fprintf(
           stderr,
-          "failed to create bridge ROS 1 service '%s' "
-          "no conversion for package '%s' and type '%s'\n",
-          service_name.c_str(), package_name.c_str(), type_name.c_str());
+          "failed to create bridge ROS 1 service '%s' no conversion for type '%s'\n",
+          service_name.c_str(), type_name.c_str());
       }
     }
 
@@ -154,15 +174,34 @@ int main(int argc, char * argv[])
   {
     for (size_t i = 0; i < static_cast<size_t>(services_2_to_1.size()); ++i) {
       std::string service_name = static_cast<std::string>(services_2_to_1[i]["service"]);
-      std::string package_name = static_cast<std::string>(services_2_to_1[i]["package"]);
       std::string type_name = static_cast<std::string>(services_2_to_1[i]["type"]);
+      {
+        // for backward compatibility
+        std::string package_name = static_cast<std::string>(services_2_to_1[i]["package"]);
+        if (!package_name.empty()) {
+          fprintf(
+            stderr,
+            "The service '%s' uses the key 'package' which is deprecated for "
+            "services. Instead prepend the 'type' value with '<package>/'.\n",
+            service_name.c_str());
+          type_name = package_name + "/" + type_name;
+        }
+      }
       printf(
-        "Trying to create bridge for ROS 1 service '%s' "
-        "with package '%s' and type '%s'\n",
-        service_name.c_str(), package_name.c_str(), type_name.c_str());
+        "Trying to create bridge for ROS 1 service '%s' with type '%s'\n",
+        service_name.c_str(), type_name.c_str());
+
+      size_t index = type_name.find("/");
+      if (index == std::string::npos) {
+        fprintf(
+          stderr,
+          "the service '%s' has a type '%s' without a slash.\n",
+          service_name.c_str(), type_name.c_str());
+        continue;
+      }
 
       auto factory = ros1_bridge::get_service_factory(
-        "ros1", package_name, type_name);
+        "ros1", type_name.substr(0, index), type_name.substr(index + 1));
       if (factory) {
         try {
           service_bridges_2_to_1.push_back(
@@ -171,16 +210,14 @@ int main(int argc, char * argv[])
         } catch (std::runtime_error & e) {
           fprintf(
             stderr,
-            "failed to create bridge ROS 2 service '%s' "
-            "with package '%s' and type '%s': %s\n",
-            service_name.c_str(), type_name.c_str(), type_name.c_str(), e.what());
+            "failed to create bridge ROS 2 service '%s' with type '%s': %s\n",
+            service_name.c_str(), type_name.c_str(), e.what());
         }
       } else {
         fprintf(
           stderr,
-          "failed to create bridge ROS 2 service '%s' "
-          "no conversion for package '%s' and type '%s'\n",
-          service_name.c_str(), package_name.c_str(), type_name.c_str());
+          "failed to create bridge ROS 2 service '%s' no conversion for type '%s'\n",
+          service_name.c_str(), type_name.c_str());
       }
     }
 


### PR DESCRIPTION
Replaces #249.

CI packaging build: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=354)](https://ci.ros2.org/job/ci_packaging_linux/354/)