### PR TITLE
use reliable publisher in simple bridge

### DIFF
--- a/src/simple_bridge.cpp
+++ b/src/simple_bridge.cpp
@@ -82,7 +82,7 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
   ros2_pub = ros2_node->create_publisher<std_msgs::msg::String>(
-    "chatter", rclcpp::SensorDataQoS());
+    "chatter", 10);
 
   // ROS 1 subscriber
   ros::Subscriber ros1_sub = ros1_node.subscribe(


### PR DESCRIPTION
Fixes #262.

As already done in the [simple_bridge_1_to_2](https://github.com/ros2/ros1_bridge/blob/37a06eb64c97571766e245b6b2784a99c1c4df69/src/simple_bridge_1_to_2.cpp#L52). Otherwise subscribes must use best effort and can't use reliable.