### PR TITLE
gracefully handle invalid ROS 1 publishers

### DIFF
--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -214,6 +214,16 @@ protected:
       }
     }
 
+    void * ptr = ros1_pub;
+    if (ptr == 0) {
+      RCLCPP_WARN_ONCE(
+        logger,
+        "Message from ROS 2 %s failed to be passed to ROS 1 %s because the "
+        "ROS 1 publisher is invalid (showing msg only once per type)",
+        ros2_type_name.c_str(), ros1_type_name.c_str());
+      return;
+    }
+
     ROS1_T ros1_msg;
     convert_2_to_1(*ros2_msg, ros1_msg);
     RCLCPP_INFO_ONCE(


### PR DESCRIPTION
A ROS 1 publisher can be invalid if multiple publishers are created with different latching attributes. If such a publisher is encounters just log a warning instead of exiting.

(The publisher is intentionally not removed since it would be added shortly after again.)

Packaging build with only FastRTPS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=358)](https://ci.ros2.org/job/ci_packaging_linux/358/)