### PR TITLE
fix removing obsolete ROS 2 service bridges

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 // include ROS 1


### PR DESCRIPTION
Fixes #265. Requires ros2/rclcpp#1131.

CI builds testing `rclcpp` with only FastRTPS:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10872)](http://ci.ros2.org/job/ci_linux/10872/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6235)](http://ci.ros2.org/job/ci_linux-aarch64/6235/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8856)](http://ci.ros2.org/job/ci_osx/8856/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10765)](http://ci.ros2.org/job/ci_windows/10765/)

Packaging build with only FastRTPS: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_packaging_linux&build=359)](https://ci.ros2.org/job/ci_packaging_linux/359/)