### PR TITLE
Fix Bridging of bool[]

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -618,12 +618,12 @@ def determine_common_services(
                     'ros1': {
                         'name': ros1_name,
                         'type': ros1_type.rstrip('[]'),
-                        'cpptype': ros1_type.rstrip('[]').replace('/', '::')
+                        'cpptype': ros1_type.rstrip('[]').replace('/', '::') if (ros1_type.find("bool[]") == -1) else "std_msgs::UInt8"
                     },
                     'ros2': {
                         'name': ros2_name,
                         'type': ros2_type.rstrip('[]'),
-                        'cpptype': ros2_type.rstrip('[]').replace('/', '::msg::')
+                        'cpptype': ros2_type.rstrip('[]').replace('/', '::msg::') if (ros2_type.find("bool[]") == -1) else "std_msgs::msg::UInt8"
                     }
                 })
         if match:


### PR DESCRIPTION
As explained in the [ROS documentation](http://wiki.ros.org/msg), the C++ type of a `bool[]` field is `std::vector<uint8_t>`. This is because `std::vector<bool>` is a vector of bytes, not booleans, and cannot easily be converted to booleans.

This change ensures that the cpptype of a `bool[]` is recorded as UInt8.

Apologies, in advance if I didn't follow the proper bug/PR process. I'm new to the community!