### PR TITLE
very minor typo in comments

### DIFF
--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -54,8 +54,8 @@ int main(int argc, char * argv[])
   const char * topics_parameter_name = "topics";
   // the services parameters need to be arrays
   // and each item needs to be a dictionary with the following keys;
-  // service: the name of the topic to bridge (e.g. '/service_name')
-  // type: the type of the topic to bridge (e.g. 'pkgname/srv/SrvName')
+  // service: the name of the service to bridge (e.g. '/service_name')
+  // type: the type of the service to bridge (e.g. 'pkgname/srv/SrvName')
   const char * services_1_to_2_parameter_name = "services_1_to_2";
   const char * services_2_to_1_parameter_name = "services_2_to_1";
   if (argc > 1) {

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -54,7 +54,7 @@ int main(int argc, char * argv[])
   const char * topics_parameter_name = "topics";
   // the services parameters need to be arrays
   // and each item needs to be a dictionary with the following keys;
-  // topic: the name of the topic to bridge (e.g. '/service_name')
+  // service: the name of the topic to bridge (e.g. '/service_name')
   // type: the type of the topic to bridge (e.g. 'pkgname/srv/SrvName')
   const char * services_1_to_2_parameter_name = "services_1_to_2";
   const char * services_2_to_1_parameter_name = "services_2_to_1";


### PR DESCRIPTION
as the documentation for parameter bridge is lacking, better to have comments without typo to avoid time waste on the user side