### PR TITLE
fix bug with sizeof when type of the arrays differ

### DIFF
--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -157,7 +157,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
 @[      else]@
   // statically sized array
   static_assert(
-    sizeof(ros2_msg.@(ros2_field_selection)) >= sizeof(ros1_msg.@(ros1_field_selection)),
+    (ros2_msg.@(ros2_field_selection).size()) >= (ros1_msg.@(ros1_field_selection).size()),
     "destination array not large enough for source array"
   );
 @[      end if]@
@@ -244,7 +244,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
 @[      else]@
   // statically sized array
   static_assert(
-    sizeof(ros1_msg.@(ros1_field_selection)) >= sizeof(ros2_msg.@(ros2_field_selection)),
+    (ros1_msg.@(ros1_field_selection).size()) >= (ros2_msg.@(ros2_field_selection).size()),
     "destination array not large enough for source array"
   );
 @[      end if]@


### PR DESCRIPTION
This patch fixes a bug where the `sizeof` calls used to compare sizes of fixed sized arrays/sequences were faulty when elements of the arrays have different memory layouts.

We've tested it against the Apex use case that was failing to compile. It's ready for review, and then I'll work on backports.