### PR TITLE
Fix logging for updated rclcpp interface

### DIFF
--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -125,7 +125,7 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size)
 {
-  RCLCPP_INFO(ros2_node->get_logger(), std::string("create bidirectional bridge for topic " + topic_name).c_str());
+  RCLCPP_INFO(ros2_node->get_logger(), ("create bidirectional bridge for topic " + topic_name).c_str());
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -125,7 +125,7 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size)
 {
-  RCLCPP_INFO(ros2_node->get_logger(), ("create bidirectional bridge for topic " + topic_name).c_str());
+  RCLCPP_INFO(ros2_node->get_logger(), "create bidirectional bridge for topic %s", topic_name.c_str());
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -125,7 +125,9 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size)
 {
-  RCLCPP_INFO(ros2_node->get_logger(), "create bidirectional bridge for topic %s", topic_name.c_str());
+  RCLCPP_INFO(
+    ros2_node->get_logger(), "create bidirectional bridge for topic %s",
+    topic_name.c_str());
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -125,7 +125,7 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size)
 {
-  RCLCPP_INFO(ros2_node->get_logger(), "create bidirectional bridge for topic " + topic_name);
+  RCLCPP_INFO(ros2_node->get_logger(), std::string("create bidirectional bridge for topic " + topic_name).c_str());
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,


### PR DESCRIPTION
This has caused failures in the nightly jobs on platforms where ros1_bridge is built.

I believe that it is related to this PR: https://github.com/ros2/rclcpp/pull/1442

@audrow Can you confirm that this was an expected side effect?