### PR TITLE
Add hardcoded QoS for the /tf_static topic for parameter bridge

### DIFF
--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -104,6 +104,7 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latching = false,
   rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
 
 Bridge2to1Handles
@@ -116,6 +117,7 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latching = false,
   rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
 
 BridgeHandles
@@ -135,7 +137,8 @@ create_bidirectional_bridge(
   const std::string & ros2_type_name,
   const std::string & topic_name,
   size_t queue_size,
-  const rclcpp::QoS & publisher_qos);
+  bool ros1_publisher_latching,
+  const rclcpp::QoS & ros2_publisher_qos);
 
 }  // namespace ros1_bridge
 

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -127,6 +127,16 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size = 10);
 
+BridgeHandles
+create_bidirectional_bridge(
+  ros::NodeHandle ros1_node,
+  rclcpp::Node::SharedPtr ros2_node,
+  const std::string & ros1_type_name,
+  const std::string & ros2_type_name,
+  const std::string & topic_name,
+  size_t queue_size,
+  const rclcpp::QoS & publisher_qos);
+
 }  // namespace ros1_bridge
 
 #endif  // ROS1_BRIDGE__BRIDGE_HPP_

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -139,4 +139,28 @@ create_bidirectional_bridge(
   return handles;
 }
 
+BridgeHandles
+create_bidirectional_bridge(
+  ros::NodeHandle ros1_node,
+  rclcpp::Node::SharedPtr ros2_node,
+  const std::string & ros1_type_name,
+  const std::string & ros2_type_name,
+  const std::string & topic_name,
+  size_t queue_size,
+  const rclcpp::QoS & publisher_qos)
+{
+  RCLCPP_INFO(
+    ros2_node->get_logger(), "create bidirectional bridge for topic %s",
+    topic_name.c_str());
+  BridgeHandles handles;
+  handles.bridge1to2 = create_bridge_from_1_to_2(
+    ros1_node, ros2_node,
+    ros1_type_name, topic_name, publisher_qos.get_rmw_qos_profile().depth, ros2_type_name, topic_name, publisher_qos);
+  handles.bridge2to1 = create_bridge_from_2_to_1(
+    ros2_node, ros1_node,
+    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+    handles.bridge1to2.ros2_publisher);
+  return handles;
+}
+
 }  // namespace ros1_bridge

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -254,11 +254,14 @@ void update_bridge(
     bridge.ros1_type_name = ros1_type_name;
     bridge.ros2_type_name = ros2_type_name;
 
+    bool ros1_pub_latching = (topic_name == "/tf_static");
+
     try {
       bridge.bridge_handles = ros1_bridge::create_bridge_from_2_to_1(
         ros2_node, ros1_node,
         bridge.ros2_type_name, topic_name, 10,
-        bridge.ros1_type_name, topic_name, 10);
+        bridge.ros1_type_name, topic_name, 10,
+        ros1_pub_latching);
     } catch (std::runtime_error & e) {
       fprintf(
         stderr,

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -87,14 +87,17 @@ int main(int argc, char * argv[])
         topic_name.c_str(), type_name.c_str());
 
       auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size));
+      bool ros1_publisher_latching = false;
       if (topic_name == "/tf_static") {
+        ros1_publisher_latching = true;
         ros2_publisher_qos.keep_all();
         ros2_publisher_qos.transient_local();
       }
 
       try {
         ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-          ros1_node, ros2_node, "", type_name, topic_name, queue_size, ros2_publisher_qos);
+          ros1_node, ros2_node, "", type_name, topic_name, queue_size, ros1_publisher_latching,
+          ros2_publisher_qos);
         all_handles.push_back(handles);
       } catch (std::runtime_error & e) {
         fprintf(

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -86,9 +86,15 @@ int main(int argc, char * argv[])
         "with ROS 2 type '%s'\n",
         topic_name.c_str(), type_name.c_str());
 
+      auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(queue_size));
+      if (topic_name == "/tf_static") {
+        ros2_publisher_qos.keep_all();
+        ros2_publisher_qos.transient_local();
+      }
+
       try {
         ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-          ros1_node, ros2_node, "", type_name, topic_name, queue_size);
+          ros1_node, ros2_node, "", type_name, topic_name, queue_size, ros2_publisher_qos);
         all_handles.push_back(handles);
       } catch (std::runtime_error & e) {
         fprintf(


### PR DESCRIPTION
Hello everyone,

the hardcoded QoS (keep all, transient local) for the /tf_static topic that were introduced to the dynamic bridge are quite useful and I think they should be added to the parameter bridge as well. This pull request introduces an API to create bidirectional bridges with adjustable QoS for the 1->2 publisher. This API is then used in the parameter bridge to change the QoS for the /tf_static topic.

Cheers
lFatality

P.S.: This is my very first pull request to an open source project so let me know if I miss some steps or something like that :)