### PR TITLE
Remove unused header

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -38,8 +38,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/scope_exit.hpp"
 
-#include "rcutils/get_env.h"
-
 #include "ros1_bridge/bridge.hpp"
 
 


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.

I simply removed the `#include` since nothing from that header was actually used.