### PR TITLE
Use FindPython3 and make Python dependency explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,12 @@ set(target_dependencies
   "resource/pkg_factories.hpp.em"
   "ros1_bridge/__init__.py")
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 add_custom_command(
   OUTPUT ${generated_files}
-  COMMAND ${PYTHON_EXECUTABLE} bin/ros1_bridge_generate_factories
+  COMMAND Python3::Interpreter
+  ARGS bin/ros1_bridge_generate_factories
     --output-path "${generated_path}" --template-dir resource
   DEPENDS ${target_dependencies}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_index_python</buildtool_depend>
+  <buildtool_depend>python3</buildtool_depend>
   <buildtool_depend>python3-catkin-pkg-modules</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_parser</buildtool_depend>


### PR DESCRIPTION
This makes `ros1_bridge` use `FindPython3`, and makes the dependency on Python 3 explicit

Related to ros2/python_cmake_module#6
Blocks ament/ament_cmake#355