### PR TITLE
Switch to using rcpputils::make_scope_exit.

### DIFF
--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -36,7 +36,7 @@
 
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp/scope_exit.hpp"
+#include "rcpputils/scope_exit.hpp"
 
 #include "ros1_bridge/bridge.hpp"
 
@@ -396,7 +396,7 @@ void get_ros1_service_info(
     return;
   }
   ros::TransportTCPPtr transport(new ros::TransportTCP(nullptr, ros::TransportTCP::SYNCHRONOUS));
-  auto transport_exit = rclcpp::make_scope_exit(
+  auto transport_exit = rcpputils::make_scope_exit(
     [transport]() {
       transport->close();
     });


### PR DESCRIPTION
This gets rid of a deprecation warning.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>