### PR TITLE
Parametrize Quality of Service in `parameter_bridge`. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(xmlrpcpp REQUIRED)
 
 # find ROS 1 packages
 set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)

--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
 If all is well, the output should contain `example_interfaces.srv.AddTwoInts_Response(sum=3)`
 
 ### Parametrizing Quality of Service
-An advantage or ROS 2 over ROS 1 is the possibility to define different Quality of Service settings per topic.
-The parameter bridge optionally allows for this as well: 
+An advantage of ROS 2 over ROS 1 is the possibility to define different Quality of Service settings per topic.
+The parameter bridge optionally allows for this as well.
 For some topics, like `/tf_static` this is actually required, as this is a latching topic in ROS 1.
 In ROS 2 with the `parameter_bridge`, this requires that topic to be configured as such:
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ topics:
     type: std_msgs/msg/String
     queue_size: 1
     qos:
-      history: keep_last  # OR keep_last, then you can omit `depth` below
+      history: keep_last  # OR keep_all, then you can omit `depth` parameter below
       depth: 10  # Only required when history == keep_last
       reliability: reliable  # OR best_effort
       durability: transient_local  # OR volatile

--- a/README.md
+++ b/README.md
@@ -419,3 +419,47 @@ This should start printing text like `I heard: [hello world ...]` with a timesta
 ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
 ```
 If all is well, the output should contain `example_interfaces.srv.AddTwoInts_Response(sum=3)`
+
+### Parametrizing Quality of Service
+An advantage or ROS 2 over ROS 1 is the possibility to define different Quality of Service settings per topic.
+The parameter bridge optionally allows for this as well: 
+For some topics, like `/tf_static` this is actually required, as this is a latching topic in ROS 1.
+In ROS 2 with the `parameter_bridge`, this requires that topic to be configured as such:
+
+```yaml
+topics:
+  -
+    topic: /tf_static
+    type: tf2_msgs/msg/TFMessage
+    queue_size: 1
+    qos:
+      history: keep_all
+      durability: transient_local
+```
+
+All other QoS options (as documented here in https://docs.ros.org/en/foxy/Concepts/About-Quality-of-Service-Settings.html) are available:
+
+```yaml
+topics:
+  -
+    topic: /some_ros1_topic
+    type: std_msgs/msg/String
+    queue_size: 1
+    qos:
+      history: keep_last  # OR keep_last, then you can omit `depth` below
+      depth: 10  # Only required when history == keep_last
+      reliability: reliable  # OR best_effort
+      durability: transient_local  # OR volatile
+      deadline:
+          secs: 10
+          nsecs: 2345
+      lifespan:
+          secs: 20
+          nsecs: 3456
+      liveliness: liveliness_system_default  # Values from https://design.ros2.org/articles/qos_deadline_liveliness_lifespan.html, eg. LIVELINESS_AUTOMATIC
+      liveliness_lease_duration:
+          secs: 40
+          nsecs: 5678
+```
+
+Note that the `qos` section can be omitted entirely and options not set are left default.

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -127,6 +127,16 @@ create_bidirectional_bridge(
   const std::string & topic_name,
   size_t queue_size = 10);
 
+BridgeHandles
+create_bidirectional_bridge(
+    ros::NodeHandle ros1_node,
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string &ros1_type_name,
+    const std::string &ros2_type_name,
+    const std::string &topic_name,
+    size_t queue_size,
+    const rclcpp::QoS &publisher_qos);
+
 }  // namespace ros1_bridge
 
 #endif  // ROS1_BRIDGE__BRIDGE_HPP_

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -129,13 +129,13 @@ create_bidirectional_bridge(
 
 BridgeHandles
 create_bidirectional_bridge(
-    ros::NodeHandle ros1_node,
-    rclcpp::Node::SharedPtr ros2_node,
-    const std::string &ros1_type_name,
-    const std::string &ros2_type_name,
-    const std::string &topic_name,
-    size_t queue_size,
-    const rclcpp::QoS &publisher_qos);
+  ros::NodeHandle ros1_node,
+  rclcpp::Node::SharedPtr ros2_node,
+  const std::string & ros1_type_name,
+  const std::string & ros2_type_name,
+  const std::string & topic_name,
+  size_t queue_size,
+  const rclcpp::QoS & publisher_qos);
 
 }  // namespace ros1_bridge
 

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>xmlrpcpp</build_depend>
 
   <buildtool_export_depend>pkg-config</buildtool_export_depend>
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -139,4 +139,28 @@ create_bidirectional_bridge(
   return handles;
 }
 
+BridgeHandles
+create_bidirectional_bridge(
+    ros::NodeHandle ros1_node,
+    rclcpp::Node::SharedPtr ros2_node,
+    const std::string &ros1_type_name,
+    const std::string &ros2_type_name,
+    const std::string &topic_name,
+    size_t queue_size,
+    const rclcpp::QoS &publisher_qos)
+{
+  RCLCPP_INFO(
+      ros2_node->get_logger(), "create bidirectional bridge for topic %s",
+      topic_name.c_str());
+  BridgeHandles handles;
+  handles.bridge1to2 = create_bridge_from_1_to_2(
+      ros1_node, ros2_node,
+      ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, publisher_qos);
+  handles.bridge2to1 = create_bridge_from_2_to_1(
+      ros2_node, ros1_node,
+      ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+      handles.bridge1to2.ros2_publisher);
+  return handles;
+}
+
 }  // namespace ros1_bridge

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -141,25 +141,25 @@ create_bidirectional_bridge(
 
 BridgeHandles
 create_bidirectional_bridge(
-    ros::NodeHandle ros1_node,
-    rclcpp::Node::SharedPtr ros2_node,
-    const std::string &ros1_type_name,
-    const std::string &ros2_type_name,
-    const std::string &topic_name,
-    size_t queue_size,
-    const rclcpp::QoS &publisher_qos)
+  ros::NodeHandle ros1_node,
+  rclcpp::Node::SharedPtr ros2_node,
+  const std::string & ros1_type_name,
+  const std::string & ros2_type_name,
+  const std::string & topic_name,
+  size_t queue_size,
+  const rclcpp::QoS & publisher_qos)
 {
   RCLCPP_INFO(
-      ros2_node->get_logger(), "create bidirectional bridge for topic %s",
-      topic_name.c_str());
+    ros2_node->get_logger(), "create bidirectional bridge for topic %s",
+    topic_name.c_str());
   BridgeHandles handles;
   handles.bridge1to2 = create_bridge_from_1_to_2(
-      ros1_node, ros2_node,
-      ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, publisher_qos);
+    ros1_node, ros2_node,
+    ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, publisher_qos);
   handles.bridge2to1 = create_bridge_from_2_to_1(
-      ros2_node, ros1_node,
-      ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
-      handles.bridge1to2.ros2_publisher);
+    ros2_node, ros1_node,
+    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+    handles.bridge1to2.ros2_publisher);
   return handles;
 }
 

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -240,3 +240,18 @@ int main(int argc, char * argv[])
 
   return 0;
 }
+
+rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
+{
+  auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+  if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct)
+  {
+  }
+  else
+  {
+    fprintf(
+      stderr,
+      "QoS parameters could not be read\n");  // TODO: clearer message
+  }
+  return ros2_publisher_qos;
+}

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -108,12 +108,12 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       } catch (std::runtime_error & e) {
         fprintf(
           stderr,
-          "failed to create parametrize deadline: '%s'\n",
+          "failed to parse deadline: '%s'\n",
           e.what());
       } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
           stderr,
-          "failed to create parametrize deadline: '%s'\n",
+          "failed to parse deadline: '%s'\n",
           e.getMessage().c_str());
       }
     }
@@ -128,19 +128,18 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       } catch (std::runtime_error & e) {
         fprintf(
           stderr,
-          "failed to create parametrize lifespan: '%s'\n",
+          "failed to parse lifespan: '%s'\n",
           e.what());
       } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
           stderr,
-          "failed to create parametrize lifespan: '%s'\n",
+          "failed to parse lifespan: '%s'\n",
           e.getMessage().c_str());
       }
     }
 
     if (qos_params.hasMember("liveliness")) {
       if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeInt) {
-        printf("liviness is an int\n");
         try {
           auto liveliness = static_cast<int>(qos_params["liveliness"]);
           ros2_publisher_qos.liveliness(static_cast<rmw_qos_liveliness_policy_t>(liveliness));
@@ -148,12 +147,12 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
         } catch (std::runtime_error & e) {
           fprintf(
             stderr,
-            "failed to create parametrize liveliness: '%s'\n",
+            "failed to parse liveliness: '%s'\n",
             e.what());
         } catch (XmlRpc::XmlRpcException & e) {
           fprintf(
             stderr,
-            "failed to create parametrize liveliness: '%s'\n",
+            "failed to parse liveliness: '%s'\n",
             e.getMessage().c_str());
         }
       } else if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeString) {
@@ -186,18 +185,18 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
         } catch (std::runtime_error & e) {
           fprintf(
             stderr,
-            "failed to create parametrize liveliness: '%s'\n",
+            "failed to parse liveliness: '%s'\n",
             e.what());
         } catch (XmlRpc::XmlRpcException & e) {
           fprintf(
             stderr,
-            "failed to create parametrize liveliness: '%s'\n",
+            "failed to parse liveliness: '%s'\n",
             e.getMessage().c_str());
         }
       } else {
         fprintf(
           stderr,
-          "failed to create parametrize liveliness, parameter was not a string or int \n");
+          "failed to parse liveliness, parameter was not a string or int \n");
       }
     }
 
@@ -211,12 +210,12 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       } catch (std::runtime_error & e) {
         fprintf(
           stderr,
-          "failed to create parametrize liveliness_lease_duration: '%s'\n",
+          "failed to parse liveliness_lease_duration: '%s'\n",
           e.what());
       } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
           stderr,
-          "failed to create parametrize liveliness_lease_duration: '%s'\n",
+          "failed to parse liveliness_lease_duration: '%s'\n",
           e.getMessage().c_str());
       }
     }

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <xmlrpcpp/XmlRpcException.h>
+
 #include <list>
 #include <string>
 
@@ -27,7 +29,6 @@
 
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
-#include <xmlrpcpp/XmlRpcException.h>
 
 #include "ros1_bridge/bridge.hpp"
 
@@ -57,7 +58,8 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       } else {
         fprintf(
           stderr,
-          "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also requires 'depth' to be set)\n",
+          "invalid value for 'history': '%s', allowed values are 'keep_all',"
+          "'keep_last' (also requires 'depth' to be set)\n",
           history.c_str());
       }
     }
@@ -163,18 +165,19 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
             liveliness_str == "liveliness_system_default")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
-          } else if (liveliness_str == "LIVELINESS_AUTOMATIC" ||
+          } else if (liveliness_str == "LIVELINESS_AUTOMATIC" ||  // NOLINT
             liveliness_str == "liveliness_automatic")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-          } else if (liveliness_str == "LIVELINESS_MANUAL_BY_TOPIC" ||
+          } else if (liveliness_str == "LIVELINESS_MANUAL_BY_TOPIC" ||  // NOLINT
             liveliness_str == "liveliness_manual_by_topic")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
           } else {
             fprintf(
               stderr,
-              "invalid value for 'liveliness': '%s', allowed values are LIVELINESS_{SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC}, upper or lower case\n",
+              "invalid value for 'liveliness': '%s', allowed values are "
+              "LIVELINESS_{SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC}, upper or lower case\n",
               liveliness_str.c_str());
           }
 
@@ -220,7 +223,7 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
   } else {
     fprintf(
       stderr,
-      "QoS parameters could not be read\n");   // TODO: clearer message
+      "QoS parameters could not be read\n");
   }
 
   printf(")");
@@ -295,7 +298,6 @@ int main(int argc, char * argv[])
             ros1_node, ros2_node, "", type_name, topic_name, queue_size);
           all_handles.push_back(handles);
         }
-
       } catch (std::runtime_error & e) {
         fprintf(
           stderr,

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -241,6 +241,7 @@ int main(int argc, char * argv[])
       try {
         if (topics[i].hasMember("qos"))
         {
+          printf("Setting up QoS for '%s'\n", topic_name.c_str());
           auto qos_settings = qos_from_params(topics[i]["qos"]);
           ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
             ros1_node, ros2_node, "", type_name, topic_name, queue_size, qos_settings);

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -246,6 +246,34 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
   auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(10));
   if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct)
   {
+    if(qos_params.hasMember("history"))
+    {
+      auto history = static_cast<std::string>(qos_params["history"]);
+      if(history == "keep_all")
+      {
+        ros2_publisher_qos.keep_all();
+      }
+      else if (history == "keep_last")
+      {
+        if(qos_params.hasMember("depth"))
+        {
+          auto depth = static_cast<int>(qos_params["depth"]);
+          ros2_publisher_qos.keep_last(depth);
+        }
+        else
+        {
+          fprintf(
+              stderr,
+              "history: keep_last requires that also a depth is set\n");
+        }
+      }
+      else
+      {
+        fprintf(
+            stderr,
+            "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also required 'depth' to be set)\n", history.c_str());
+      }
+    }
   }
   else
   {

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -36,245 +36,191 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
   auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(10));
 
   printf("Qos(");
-  
-  if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct)
-  {
-    if (qos_params.hasMember("history"))
-    {
+
+  if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct) {
+    if (qos_params.hasMember("history")) {
       auto history = static_cast<std::string>(qos_params["history"]);
       printf("history: ");
-      if (history == "keep_all")
-      {
+      if (history == "keep_all") {
         ros2_publisher_qos.keep_all();
         printf("keep_all, ");
-      }
-      else if (history == "keep_last")
-      {
-        if (qos_params.hasMember("depth"))
-        {
+      } else if (history == "keep_last") {
+        if (qos_params.hasMember("depth")) {
           auto depth = static_cast<int>(qos_params["depth"]);
           ros2_publisher_qos.keep_last(depth);
           printf("keep_last(%i), ", depth);
-        }
-        else
-        {
+        } else {
           fprintf(
-              stderr,
-              "history: keep_last requires that also a depth is set\n");
-        }
-      }
-      else
-      {
-        fprintf(
             stderr,
-            "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also requires 'depth' to be set)\n", history.c_str());
+            "history: keep_last requires that also a depth is set\n");
+        }
+      } else {
+        fprintf(
+          stderr,
+          "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also requires 'depth' to be set)\n",
+          history.c_str());
       }
     }
 
-    if (qos_params.hasMember("reliability"))
-    {
+    if (qos_params.hasMember("reliability")) {
       auto reliability = static_cast<std::string>(qos_params["reliability"]);
       printf("reliability: ");
-      if (reliability == "best_effort")
-      {
+      if (reliability == "best_effort") {
         ros2_publisher_qos.best_effort();
         printf("best_effort, ");
-      }
-      else if (reliability == "reliable")
-      {
+      } else if (reliability == "reliable") {
         ros2_publisher_qos.reliable();
         printf("reliable, ");
-      }
-      else
-      {
+      } else {
         fprintf(
-            stderr,
-            "invalid value for 'reliability': '%s', allowed values are 'best_effort', 'reliable'\n", reliability.c_str());
+          stderr,
+          "invalid value for 'reliability': '%s', allowed values are 'best_effort', 'reliable'\n",
+          reliability.c_str());
       }
     }
 
-    if (qos_params.hasMember("durability"))
-    {
+    if (qos_params.hasMember("durability")) {
       auto durability = static_cast<std::string>(qos_params["durability"]);
       printf("durability: ");
-      if (durability == "transient_local")
-      {
+      if (durability == "transient_local") {
         ros2_publisher_qos.transient_local();
         printf("transient_local, ");
-      }
-      else if (durability == "volatile")
-      {
+      } else if (durability == "volatile") {
         ros2_publisher_qos.durability_volatile();
         printf("volatile, ");
-      }
-      else
-      {
+      } else {
         fprintf(
-            stderr,
-            "invalid value for 'durability': '%s', allowed values are 'best_effort', 'volatile'\n", durability.c_str());
+          stderr,
+          "invalid value for 'durability': '%s', allowed values are 'best_effort', 'volatile'\n",
+          durability.c_str());
       }
     }
 
-    if (qos_params.hasMember("deadline"))
-    {
-      try
-      {
+    if (qos_params.hasMember("deadline")) {
+      try {
         rclcpp::Duration dur = rclcpp::Duration(
-                static_cast<int>(qos_params["deadline"]["secs"]),
-                static_cast<int>(qos_params["deadline"]["nsecs"]));
+          static_cast<int>(qos_params["deadline"]["secs"]),
+          static_cast<int>(qos_params["deadline"]["nsecs"]));
         ros2_publisher_qos.deadline(dur);
         printf("deadline: Duration(nsecs: %ld), ", dur.nanoseconds());
-      }
-      catch (std::runtime_error &e)
-      {
+      } catch (std::runtime_error & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize deadline: '%s'\n",
-            e.what());
-      }
-      catch (XmlRpc::XmlRpcException &e)
-      {
+          stderr,
+          "failed to create parametrize deadline: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize deadline: '%s'\n",
-            e.getMessage().c_str());
+          stderr,
+          "failed to create parametrize deadline: '%s'\n",
+          e.getMessage().c_str());
       }
     }
 
-    if (qos_params.hasMember("lifespan"))
-    {
-      try
-      {
+    if (qos_params.hasMember("lifespan")) {
+      try {
         rclcpp::Duration dur = rclcpp::Duration(
-                                   static_cast<int>(qos_params["lifespan"]["secs"]),
-                                   static_cast<int>(qos_params["lifespan"]["nsecs"]));
-                                   ros2_publisher_qos.lifespan(dur);
+          static_cast<int>(qos_params["lifespan"]["secs"]),
+          static_cast<int>(qos_params["lifespan"]["nsecs"]));
+        ros2_publisher_qos.lifespan(dur);
         printf("lifespan: Duration(nsecs: %ld), ", dur.nanoseconds());
-      }
-      catch (std::runtime_error &e)
-      {
+      } catch (std::runtime_error & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize lifespan: '%s'\n",
-            e.what());
-      }
-      catch (XmlRpc::XmlRpcException &e)
-      {
+          stderr,
+          "failed to create parametrize lifespan: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize lifespan: '%s'\n",
-            e.getMessage().c_str());
+          stderr,
+          "failed to create parametrize lifespan: '%s'\n",
+          e.getMessage().c_str());
       }
     }
 
-    if (qos_params.hasMember("liveliness"))
-    {
-      if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeInt)
-      {
+    if (qos_params.hasMember("liveliness")) {
+      if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeInt) {
         printf("liviness is an int\n");
-        try
-        {
+        try {
           auto liveliness = static_cast<int>(qos_params["liveliness"]);
           ros2_publisher_qos.liveliness(static_cast<rmw_qos_liveliness_policy_t>(liveliness));
           printf("liveliness: %i, ", static_cast<int>(liveliness));
-        }
-        catch (std::runtime_error &e)
-        {
+        } catch (std::runtime_error & e) {
           fprintf(
-              stderr,
-              "failed to create parametrize liveliness: '%s'\n",
-              e.what());
-        }
-        catch (XmlRpc::XmlRpcException &e)
-        {
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.what());
+        } catch (XmlRpc::XmlRpcException & e) {
           fprintf(
-              stderr,
-              "failed to create parametrize liveliness: '%s'\n",
-              e.getMessage().c_str());
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.getMessage().c_str());
         }
-      }
-      else if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeString)
-      {
-        try
-        {
-          rmw_qos_liveliness_policy_t liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+      } else if (qos_params["liveliness"].getType() == XmlRpc::XmlRpcValue::TypeString) {
+        try {
+          rmw_qos_liveliness_policy_t liveliness =
+            rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
           auto liveliness_str = static_cast<std::string>(qos_params["liveliness"]);
-          if (liveliness_str == "LIVELINESS_SYSTEM_DEFAULT" || liveliness_str == "liveliness_system_default")
+          if (liveliness_str == "LIVELINESS_SYSTEM_DEFAULT" ||
+            liveliness_str == "liveliness_system_default")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
-          }
-          else if (liveliness_str == "LIVELINESS_AUTOMATIC" || liveliness_str == "liveliness_automatic")
+          } else if (liveliness_str == "LIVELINESS_AUTOMATIC" ||
+            liveliness_str == "liveliness_automatic")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-          }
-          else if (liveliness_str == "LIVELINESS_MANUAL_BY_TOPIC" || liveliness_str == "liveliness_manual_by_topic")
+          } else if (liveliness_str == "LIVELINESS_MANUAL_BY_TOPIC" ||
+            liveliness_str == "liveliness_manual_by_topic")
           {
             liveliness = rmw_qos_liveliness_policy_t::RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-          }
-          else
-          {
+          } else {
             fprintf(
-                stderr,
-                "invalid value for 'liveliness': '%s', allowed values are LIVELINESS_{SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC}, upper or lower case\n", liveliness_str.c_str());
+              stderr,
+              "invalid value for 'liveliness': '%s', allowed values are LIVELINESS_{SYSTEM_DEFAULT, AUTOMATIC, MANUAL_BY_TOPIC}, upper or lower case\n",
+              liveliness_str.c_str());
           }
 
           ros2_publisher_qos.liveliness(liveliness);
           printf("liveliness: %s, ", liveliness_str.c_str());
-        }
-        catch (std::runtime_error &e)
-        {
+        } catch (std::runtime_error & e) {
           fprintf(
-              stderr,
-              "failed to create parametrize liveliness: '%s'\n",
-              e.what());
-        }
-        catch (XmlRpc::XmlRpcException &e)
-        {
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.what());
+        } catch (XmlRpc::XmlRpcException & e) {
           fprintf(
-              stderr,
-              "failed to create parametrize liveliness: '%s'\n",
-              e.getMessage().c_str());
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.getMessage().c_str());
         }
-      }
-      else
-      {
+      } else {
         fprintf(
           stderr,
           "failed to create parametrize liveliness, parameter was not a string or int \n");
       }
     }
 
-    if (qos_params.hasMember("liveliness_lease_duration"))
-    {
-      try
-      {
+    if (qos_params.hasMember("liveliness_lease_duration")) {
+      try {
         rclcpp::Duration dur = rclcpp::Duration(
-                                   static_cast<int>(qos_params["liveliness_lease_duration"]["secs"]),
-                                   static_cast<int>(qos_params["liveliness_lease_duration"]["nsecs"]));
-                                   ros2_publisher_qos.liveliness_lease_duration(dur);
+          static_cast<int>(qos_params["liveliness_lease_duration"]["secs"]),
+          static_cast<int>(qos_params["liveliness_lease_duration"]["nsecs"]));
+        ros2_publisher_qos.liveliness_lease_duration(dur);
         printf("liveliness_lease_duration: Duration(nsecs: %ld), ", dur.nanoseconds());
-      }
-      catch (std::runtime_error &e)
-      {
+      } catch (std::runtime_error & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize liveliness_lease_duration: '%s'\n",
-            e.what());
-      }
-      catch (XmlRpc::XmlRpcException &e)
-      {
+          stderr,
+          "failed to create parametrize liveliness_lease_duration: '%s'\n",
+          e.what());
+      } catch (XmlRpc::XmlRpcException & e) {
         fprintf(
-            stderr,
-            "failed to create parametrize liveliness_lease_duration: '%s'\n",
-            e.getMessage().c_str());
+          stderr,
+          "failed to create parametrize liveliness_lease_duration: '%s'\n",
+          e.getMessage().c_str());
       }
     }
-  }
-  else
-  {
+  } else {
     fprintf(
-        stderr,
-        "QoS parameters could not be read\n"); // TODO: clearer message
+      stderr,
+      "QoS parameters could not be read\n");   // TODO: clearer message
   }
 
   printf(")");
@@ -337,22 +283,19 @@ int main(int argc, char * argv[])
         topic_name.c_str(), type_name.c_str());
 
       try {
-        if (topics[i].hasMember("qos"))
-        {
+        if (topics[i].hasMember("qos")) {
           printf("Setting up QoS for '%s': ", topic_name.c_str());
           auto qos_settings = qos_from_params(topics[i]["qos"]);
           printf("\n");
           ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
             ros1_node, ros2_node, "", type_name, topic_name, queue_size, qos_settings);
           all_handles.push_back(handles);
-        }
-        else
-        {
+        } else {
           ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
             ros1_node, ros2_node, "", type_name, topic_name, queue_size);
           all_handles.push_back(handles);
         }
-        
+
       } catch (std::runtime_error & e) {
         fprintf(
           stderr,

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -140,6 +140,22 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       }
     }
 
+    if (qos_params.hasMember("liveliness"))
+    {
+      try
+      {
+        auto liveliness = static_cast<int>(qos_params["liveliness"]);
+        ros2_publisher_qos.liveliness(static_cast<rmw_qos_liveliness_policy_t>(liveliness));
+      }
+      catch (std::runtime_error &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.what());
+      }
+    }
+
     if (qos_params.hasMember("liveliness_lease_duration"))
     {
       try

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -33,6 +33,7 @@
 rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
 {
   auto ros2_publisher_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+  
   if (qos_params.getType() == XmlRpc::XmlRpcValue::TypeStruct)
   {
     if (qos_params.hasMember("history"))
@@ -60,7 +61,100 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
       {
         fprintf(
             stderr,
-            "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also required 'depth' to be set)\n", history.c_str());
+            "invalid value for 'history': '%s', allowed values are 'keep_all', 'keep_last' (also requires 'depth' to be set)\n", history.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("reliability"))
+    {
+      auto reliability = static_cast<std::string>(qos_params["reliability"]);
+      if (reliability == "best_effort")
+      {
+        ros2_publisher_qos.best_effort();
+      }
+      else if (reliability == "reliable")
+      {
+        ros2_publisher_qos.reliable();
+      }
+      else
+      {
+        fprintf(
+            stderr,
+            "invalid value for 'reliability': '%s', allowed values are 'best_effort', 'reliable'\n", reliability.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("durability"))
+    {
+      auto durability = static_cast<std::string>(qos_params["durability"]);
+      if (durability == "transient_local")
+      {
+        ros2_publisher_qos.transient_local();
+      }
+      else if (durability == "volatile")
+      {
+        ros2_publisher_qos.durability_volatile();
+      }
+      else
+      {
+        fprintf(
+            stderr,
+            "invalid value for 'durability': '%s', allowed values are 'best_effort', 'volatile'\n", durability.c_str());
+      }
+    }
+
+    if (qos_params.hasMember("deadline"))
+    {
+      try
+      {
+        ros2_publisher_qos.deadline(
+          rclcpp::Duration(
+            static_cast<int>(qos_params["deadline"]["secs"]),
+            static_cast<int>(qos_params["deadline"]["nsecs"]))
+        );
+      }
+      catch (std::runtime_error &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize deadline: '%s'\n",
+            e.what());
+      }
+    }
+
+    if (qos_params.hasMember("lifespan"))
+    {
+      try
+      {
+        ros2_publisher_qos.lifespan(
+            rclcpp::Duration(
+                static_cast<int>(qos_params["lifespan"]["secs"]),
+                static_cast<int>(qos_params["lifespan"]["nsecs"])));
+      }
+      catch (std::runtime_error &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize lifespan: '%s'\n",
+            e.what());
+      }
+    }
+
+    if (qos_params.hasMember("liveliness_lease_duration"))
+    {
+      try
+      {
+        ros2_publisher_qos.liveliness_lease_duration(
+            rclcpp::Duration(
+                static_cast<int>(qos_params["liveliness_lease_duration"]["secs"]),
+                static_cast<int>(qos_params["liveliness_lease_duration"]["nsecs"])));
+      }
+      catch (std::runtime_error &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize liveliness_lease_duration: '%s'\n",
+            e.what());
       }
     }
   }

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -27,6 +27,7 @@
 
 // include ROS 2
 #include "rclcpp/rclcpp.hpp"
+#include <xmlrpcpp/XmlRpcException.h>
 
 #include "ros1_bridge/bridge.hpp"
 
@@ -131,6 +132,13 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
             "failed to create parametrize deadline: '%s'\n",
             e.what());
       }
+      catch (XmlRpc::XmlRpcException &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize deadline: '%s'\n",
+            e.getMessage().c_str());
+      }
     }
 
     if (qos_params.hasMember("lifespan"))
@@ -150,6 +158,13 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
             "failed to create parametrize lifespan: '%s'\n",
             e.what());
       }
+      catch (XmlRpc::XmlRpcException &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize lifespan: '%s'\n",
+            e.getMessage().c_str());
+      }
     }
 
     if (qos_params.hasMember("liveliness"))
@@ -166,6 +181,13 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
             stderr,
             "failed to create parametrize liveliness: '%s'\n",
             e.what());
+      }
+      catch (XmlRpc::XmlRpcException &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize liveliness: '%s'\n",
+            e.getMessage().c_str());
       }
     }
 
@@ -185,6 +207,13 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
             stderr,
             "failed to create parametrize liveliness_lease_duration: '%s'\n",
             e.what());
+      }
+      catch (XmlRpc::XmlRpcException &e)
+      {
+        fprintf(
+            stderr,
+            "failed to create parametrize liveliness_lease_duration: '%s'\n",
+            e.getMessage().c_str());
       }
     }
   }


### PR DESCRIPTION
Had some trouble using the `parameter_bridge` with `/tf_static` Turns out, I/m not the only one: https://answers.ros.org/question/349230/problem-passing-tf_static-through-ros1_bridge-to-ros2/ . The `dynamic_bridge` has an special case for this topic introduced in https://github.com/ros2/ros1_bridge/pull/282, but not in the `parameter_bridge`. 

To tackle that and be the most general I could be, I extended the `parameter_bridge` to set specific QoS settings per topic, allowing one the implement that special case if required. 

I've used this config for testing (also with different and illegal values for the settings):

`bridge.yaml`. 
```yaml
topics:
  - 
    topic: /chatter  # ROS1 topic name
    type: std_msgs/msg/String  # ROS2 type name
    queue_size: 1  # For the publisher back to ROS1
  - 
    topic: /joint_states
    type: sensor_msgs/msg/JointState
    queue_size: 1
  - 
    topic: /message_to_ros
    type: std_msgs/msg/String
    queue_size: 1
  - 
    topic: /message_from_ros
    type: std_msgs/msg/String
    queue_size: 1
    qos:
      history: keep_last
      depth: 10
      reliability: reliable
      durability: transient_local
      deadline: 
          secs: 10
          nsecs: 2345
      lifespan: 
          secs: 20
          nsecs: 3456
      liveliness: LIVELINESS_AUTOMATIC
      liveliness_lease_duration: 
          secs: 40
          nsecs: 5678
  - 
    topic: /tf
    type: tf2_msgs/msg/TFMessage
    queue_size: 1
  - 
    topic: /tf_static
    type: tf2_msgs/msg/TFMessage
    queue_size: 1
    qos:
      history: keep_all
      durability: transient_local
```

Usage of the `parameter_bridge` is explained in https://github.com/ros2/ros1_bridge/pull/330, this `bridge.yaml` is can be used in the same way. 