### PR TITLE
Parametrizing service execution timeout

### DIFF
--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -319,8 +319,9 @@ public:
       auto response2 = future.get();
       translate_2_to_1(*response2, response1);
     } else {
-      RCLCPP_ERROR(logger, "Failed to get response from ROS 2 service %s within %d seconds",
-       cli->get_service_name(), service_execution_timeout);
+      RCLCPP_ERROR(
+        logger, "Failed to get response from ROS 2 service %s within %d seconds",
+        cli->get_service_name(), service_execution_timeout);
       return false;
     }
     return true;

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -123,7 +123,7 @@ class ServiceFactoryInterface
 {
 public:
   virtual ServiceBridge1to2 service_bridge_1_to_2(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &) = 0;
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &, int) = 0;
 
   virtual ServiceBridge2to1 service_bridge_2_to_1(
     ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &) = 0;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -327,8 +327,9 @@ void update_bridge(
     }
   }
 
-  int service_execution_timeout;
-  ros1_node.param<int>("service_execution_timeout", service_execution_timeout, 5);
+  int service_execution_timeout{5};
+  ros1_node.getParamCached(
+    "ros1_bridge/dynamic_bridge/service_execution_timeout", service_execution_timeout);
 
   // create bridges for ros2 services
   for (auto & service : ros2_services) {

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -327,6 +327,9 @@ void update_bridge(
     }
   }
 
+  int service_execution_timeout;
+  ros1_node.param<int>("service_execution_timeout", service_execution_timeout, 5);
+
   // create bridges for ros2 services
   for (auto & service : ros2_services) {
     auto & name = service.first;
@@ -339,7 +342,8 @@ void update_bridge(
         "ros2", details.at("package"), details.at("name"));
       if (factory) {
         try {
-          service_bridges_1_to_2[name] = factory->service_bridge_1_to_2(ros1_node, ros2_node, name);
+          service_bridges_1_to_2[name] = factory->service_bridge_1_to_2(
+            ros1_node, ros2_node, name, service_execution_timeout);
           printf("Created 1 to 2 bridge for service %s\n", name.data());
         } catch (std::runtime_error & e) {
           fprintf(stderr, "Failed to created a bridge: %s\n", e.what());

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -58,7 +58,8 @@ int main(int argc, char * argv[])
   // type: the type of the service to bridge (e.g. 'pkgname/srv/SrvName')
   const char * services_1_to_2_parameter_name = "services_1_to_2";
   const char * services_2_to_1_parameter_name = "services_2_to_1";
-  const char * service_execution_timeout_parameter_name = "service_execution_timeout";
+  const char * service_execution_timeout_parameter_name =
+    "ros1_bridge/parameter_bridge/service_execution_timeout";
   if (argc > 1) {
     topics_parameter_name = argv[1];
   }
@@ -111,9 +112,9 @@ int main(int argc, char * argv[])
     ros1_node.getParam(services_1_to_2_parameter_name, services_1_to_2) &&
     services_1_to_2.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
-    int service_execution_timeout;
-    ros1_node.param<int>(
-      service_execution_timeout_parameter_name, service_execution_timeout, 5);
+    int service_execution_timeout{5};
+    ros1_node.getParamCached(
+      service_execution_timeout_parameter_name, service_execution_timeout);
     for (size_t i = 0; i < static_cast<size_t>(services_1_to_2.size()); ++i) {
       std::string service_name = static_cast<std::string>(services_1_to_2[i]["service"]);
       std::string type_name = static_cast<std::string>(services_1_to_2[i]["type"]);

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -58,6 +58,7 @@ int main(int argc, char * argv[])
   // type: the type of the service to bridge (e.g. 'pkgname/srv/SrvName')
   const char * services_1_to_2_parameter_name = "services_1_to_2";
   const char * services_2_to_1_parameter_name = "services_2_to_1";
+  const char * service_execution_timeout_parameter_name = "service_execution_timeout";
   if (argc > 1) {
     topics_parameter_name = argv[1];
   }
@@ -110,6 +111,9 @@ int main(int argc, char * argv[])
     ros1_node.getParam(services_1_to_2_parameter_name, services_1_to_2) &&
     services_1_to_2.getType() == XmlRpc::XmlRpcValue::TypeArray)
   {
+    int service_execution_timeout;
+    ros1_node.param<int>(
+      service_execution_timeout_parameter_name, service_execution_timeout, 5);
     for (size_t i = 0; i < static_cast<size_t>(services_1_to_2.size()); ++i) {
       std::string service_name = static_cast<std::string>(services_1_to_2[i]["service"]);
       std::string type_name = static_cast<std::string>(services_1_to_2[i]["type"]);
@@ -143,7 +147,7 @@ int main(int argc, char * argv[])
         try {
           service_bridges_1_to_2.push_back(
             factory->service_bridge_1_to_2(
-              ros1_node, ros2_node, service_name));
+              ros1_node, ros2_node, service_name, service_execution_timeout));
           printf("Created 1 to 2 bridge for service %s\n", service_name.c_str());
         } catch (std::runtime_error & e) {
           fprintf(


### PR DESCRIPTION
By convention, service calls in ROS should have a short execution time. However, since the bridge currently doesn't yet have full support for actions, services are sometimes used where a bit of computation time is needed.

Currently the service call timeout on service_bridge_1_to_2 is hard-coded to 5 seconds for all services. This constrain is not transparent to the user, that needs to take a look at the code to understand what's going on.

The PR adds a new parameter, "service_execution_timeout", that can be set by the user to extend (or reduce) the required timeout for service calls. This was added for both the dynamic_bridge and the parameter_bridge.