### PR TITLE
Cleanup of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ These are defined as the paths to the installation location of their respective 
 If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` will be `/opt/ros/noetic`.
 
 Building the bridge as described below requires you to build all of ROS 2.
-We assume that you have downloaded it to `~/ros2_galactic`, and that is where you plan on building it.
-In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_galactic/install`.
+We assume that you have downloaded it to `~/ros2_rolling`, and that is where you plan on building it.
+In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_rolling/install`.
 
 If you've chosen to install either or both versions of ROS somewhere else, you will need adjust the definitions below to match your installation paths.
 
@@ -63,7 +63,7 @@ Modify these definitions as appropriate for the versions of ROS that you're usin
 
 ```bash
 export ROS1_INSTALL_PATH=/opt/ros/noetic
-export ROS2_INSTALL_PATH=~/ros2_galactic/install
+export ROS2_INSTALL_PATH=~/ros2_rolling/install
 ```
 
 Note that no trailing '/' character is used in either definition.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Building the bridge as described below requires you to build all of ROS 2. I ass
 
 If you've chosen to install either or both versions of ROS somewhere else, you will need adjust the definitions below to match your installation paths.
 
-Because these definitions are used continuously throughout this file, it would be useful to copy the following lines to your `.bashrc` file (if you're using `bash` as your shell).  Modify these definitions as appropriate for the versions of ROS that you're using, and for the shell that you're using.
+Because these definitions are used continuously throughout this file, it would be useful to copy the following lines to your `.bashrc` file (if you're using `bash` as your shell).
+Modify these definitions as appropriate for the versions of ROS that you're using, and for the shell that you're using.
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ We don't recommend having your ROS 1 environment sourced during this step as it 
 colcon build --symlink-install --packages-skip ros1_bridge
 ```
 
-Next you need to source the ROS 1 environment.  If you set up the `ROS1_INSTALL_PATH` environment variable as described earlier, then the following will source the correct `setup.bash` file.
+Next you need to source the ROS 1 environment.
+If you set the `ROS1_INSTALL_PATH` environment variable as described above, then the following will source the correct `setup.bash` file.
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ arguments. We don't recommend having your ROS 1 environment sourced during this
 step as it can add other libraries to the path.
 
 
-```
+```bash
 colcon build --symlink-install --packages-skip ros1_bridge
 ```
 
@@ -89,7 +89,7 @@ Next you need to source the ROS 1 environment, for Linux and ROS Melodic that
 would be:
 
 
-```
+```bash
 source /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
@@ -105,7 +105,7 @@ it builds the bridge. Alternatively you can do it manually by sourcing the
 relevant workspaces yourself, e.g.:
 
 
-```
+```bash
 # You have already sourced your ROS installation.
 # Source your ROS 2 installation:
 . <install-space-with-ros2>/local_setup.bash
@@ -118,7 +118,7 @@ relevant workspaces yourself, e.g.:
 Then build just the ROS 1 bridge:
 
 
-```
+```bash
 colcon build --symlink-install --packages-select ros1_bridge --cmake-force-configure
 ```
 
@@ -142,7 +142,7 @@ in their environment.
 First we start a ROS 1 `roscore`:
 
 
-```
+```bash
 # Shell A (ROS 1 only):
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -157,7 +157,7 @@ topics. Once a *matching* topic has been detected it starts to bridge the
 messages on this topic.
 
 
-```
+```bash
 # Shell B (ROS 1 + ROS 2):
 # Source ROS 1 first:
 . /opt/ros/melodic/setup.bash
@@ -179,7 +179,7 @@ ROS 2 in a regular interval.
 Now we start the ROS 1 talker.
 
 
-```
+```bash
 # Shell C:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -194,7 +194,7 @@ The ROS 1 node will start printing the published messages to the console.
 Now we start the ROS 2 listener from the `demo_nodes_cpp` ROS 2 package.
 
 
-```
+```bash
 # Shell D:
 . <install-space-with-ros2>/setup.bash
 ros2 run demo_nodes_cpp listener
@@ -206,7 +206,7 @@ When looking at the output in *shell B* there will be a line stating that the
 bridge for this topic has been created:
 
 
-```
+```bash
 created 1to2 bridge for topic '/chatter' with ROS 1 type 'std_msgs/String' and ROS 2 type 'std_msgs/String'
 ```
 
@@ -215,7 +215,7 @@ the listener in *shell B* a line will be stating that the bridge has been torn
 down:
 
 
-```
+```bash
 removed 1to2 bridge for topic '/chatter'
 ```
 
@@ -230,7 +230,7 @@ The steps are very similar to the previous example and therefore only the
 commands are described.
 
 
-```
+```bash
 # Shell A:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -241,7 +241,7 @@ roscore
 ---
 
 
-```
+```bash
 # Shell B:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -255,7 +255,7 @@ ros2 run ros1_bridge dynamic_bridge
 
 Now we start the ROS 2 talker from the `demo_nodes_py` ROS 2 package.
 
-```
+```bash
 # Shell C:
 . <install-space-with-ros2>/setup.bash
 ros2 run demo_nodes_py talker
@@ -265,7 +265,7 @@ ros2 run demo_nodes_py talker
 
 Now we start the ROS 1 listener.
 
-```
+```bash
 # Shell D:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -283,7 +283,7 @@ node.
 
 First we start a ROS 1 `roscore` and the bridge:
 
-```
+```bash
 # Shell A:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -291,7 +291,7 @@ First we start a ROS 1 `roscore` and the bridge:
 roscore
 ```
 
-```
+```bash
 # Shell B:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -305,7 +305,7 @@ ros2 run ros1_bridge dynamic_bridge
 
 Now we start the ROS 1 GUI:
 
-```
+```bash
 # Shell C:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -316,7 +316,7 @@ rqt_image_view /image
 ---
 
 Now we start the ROS 2 image publisher from the `image_tools` ROS 2 package:
-```
+```bash
 # Shell D:
 . <workspace-with-ros2>/install/setup.bash
 ros2 run image_tools cam2image
@@ -335,7 +335,7 @@ image before sending it. You can either use the `Message Publisher` plugin in
 one of the two following `rostopic` commands:
 
 
-```
+```bash
 # Shell E:
 . /opt/ros/melodic/setup.bash
 # Or, on OSX, something like:
@@ -368,7 +368,7 @@ build ros1_bridge.
 
 Launch ROS master
 
-```
+```bash
 # Shell A:
 . <ros-install-dir>/setup.bash
 roscore -p 11311
@@ -376,7 +376,7 @@ roscore -p 11311
 
 Launch dynamic_bridge:
 
-```
+```bash
 # Shell B:
 . <ros-install-dir>/setup.bash
 . <ros2-install-dir>/setup.bash
@@ -386,7 +386,7 @@ ros2 run ros1_bridge dynamic_bridge
 
 Launch TwoInts server:
 
-```
+```bash
 # Shell C:
 . <ros-install-dir>/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
@@ -395,7 +395,7 @@ rosrun roscpp_tutorials add_two_ints_server
 
 Launch AddTwoInts client:
 
-```
+```bash
 # Shell D:
 . <ros2-install-dir>/setup.bash
 ros2 run demo_nodes_cpp add_two_ints_client

--- a/README.md
+++ b/README.md
@@ -60,6 +60,39 @@ To run the following examples you will also need these ROS 1 packages:
 * `rostopic`
 * `rqt_image_view`
 
+### Prerequisites for the examples in this file
+
+In order to make the examples below portable between versions of ROS, we've
+chosen to define two environment variables, `ROS1_INSTALL_PATH` and
+`ROS2_INSTALL_PATH`.  These are defined as the paths to the installation
+location of their respective ROS versions.
+
+If you installed Noetic in the default location, then the definition of
+`ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
+
+Building the bridge as described below requires you to build all of ROS 2. I
+assume that you have downloaded it to `~/ros2_galactic`, and that is where you
+plan on building it. In this case, `ROS2_INSTALL_PATH` will be defined as
+`~/ros2_galactic/install`.
+
+If you've chosen to install either or both versions of ROS somewhere else, you
+will need adjust the definitions below to match your installation paths.
+
+Because these definitions are used continuously throughout this file, it would
+be useful to copy the following lines to your `.bashrc` file (if you're using
+`bash` as your shell).  Modify these definitions as appropriate for the
+versions of ROS that you're using, and for the shell that you're using.
+
+```bash
+export ROS1_INSTALL_PATH=/opt/ros/noetic
+export ROS2_INSTALL_PATH=~/ros2_galactic/install
+```
+
+As a note, there is no trailing '/' character in either definition.  If you have
+problems involving paths, please verify that you have the correct path to the
+installation location, and that you do not have a trailing '/' in either
+definition.
+
 ### Building the bridge from source
 
 Before continuing you should have the prerequisites for building ROS 2 from
@@ -90,7 +123,7 @@ would be:
 
 
 ```bash
-source /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 ```
@@ -108,7 +141,7 @@ relevant workspaces yourself, e.g.:
 ```bash
 # You have already sourced your ROS installation.
 # Source your ROS 2 installation:
-. <install-space-with-ros2>/local_setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 # And if you have a ROS 1 overlay workspace, something like:
 # . <install-space-to-ros1-overlay-ws>/setup.bash
 # And if you have a ROS 2 overlay workspace, something like:
@@ -144,7 +177,7 @@ First we start a ROS 1 `roscore`:
 
 ```bash
 # Shell A (ROS 1 only):
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 roscore
@@ -160,11 +193,11 @@ messages on this topic.
 ```bash
 # Shell B (ROS 1 + ROS 2):
 # Source ROS 1 first:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 # Source ROS 2 next:
-. <install-space-with-bridge>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 # For example:
 # . /opt/ros/dashing/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
@@ -181,7 +214,7 @@ Now we start the ROS 1 talker.
 
 ```bash
 # Shell C:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 rosrun rospy_tutorials talker
@@ -196,7 +229,7 @@ Now we start the ROS 2 listener from the `demo_nodes_cpp` ROS 2 package.
 
 ```bash
 # Shell D:
-. <install-space-with-ros2>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run demo_nodes_cpp listener
 ```
 
@@ -232,7 +265,7 @@ commands are described.
 
 ```bash
 # Shell A:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 roscore
@@ -243,10 +276,10 @@ roscore
 
 ```bash
 # Shell B:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
-. <install-space-with-bridge>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```
@@ -257,7 +290,7 @@ Now we start the ROS 2 talker from the `demo_nodes_py` ROS 2 package.
 
 ```bash
 # Shell C:
-. <install-space-with-ros2>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run demo_nodes_py talker
 ```
 
@@ -267,7 +300,7 @@ Now we start the ROS 1 listener.
 
 ```bash
 # Shell D:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 rosrun roscpp_tutorials listener
@@ -285,7 +318,7 @@ First we start a ROS 1 `roscore` and the bridge:
 
 ```bash
 # Shell A:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 roscore
@@ -293,10 +326,10 @@ roscore
 
 ```bash
 # Shell B:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
-. <workspace-with-bridge>/install/setup.bash
+source ${ROS2_INSTALL_PATH}/install/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```
@@ -307,7 +340,7 @@ Now we start the ROS 1 GUI:
 
 ```bash
 # Shell C:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 rqt_image_view /image
@@ -318,7 +351,7 @@ rqt_image_view /image
 Now we start the ROS 2 image publisher from the `image_tools` ROS 2 package:
 ```bash
 # Shell D:
-. <workspace-with-ros2>/install/setup.bash
+source ${ROS2_INSTALL_PATH}/install/setup.bash
 ros2 run image_tools cam2image
 ```
 
@@ -337,7 +370,7 @@ one of the two following `rostopic` commands:
 
 ```bash
 # Shell E:
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 rostopic pub -r 1 /flip_image std_msgs/Bool "{data: true}"
@@ -370,7 +403,7 @@ Launch ROS master
 
 ```bash
 # Shell A:
-. <ros-install-dir>/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 roscore -p 11311
 ```
 
@@ -378,8 +411,8 @@ Launch dynamic_bridge:
 
 ```bash
 # Shell B:
-. <ros-install-dir>/setup.bash
-. <ros2-install-dir>/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```
@@ -388,7 +421,7 @@ Launch TwoInts server:
 
 ```bash
 # Shell C:
-. <ros-install-dir>/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 export ROS_MASTER_URI=http://localhost:11311
 rosrun roscpp_tutorials add_two_ints_server
 ```
@@ -397,7 +430,7 @@ Launch AddTwoInts client:
 
 ```bash
 # Shell D:
-. <ros2-install-dir>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run demo_nodes_cpp add_two_ints_client
 ```
 
@@ -428,7 +461,7 @@ Start a ROS 1 roscore:
 
 ```bash
 # Shell A (ROS 1 only):
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 roscore
@@ -439,7 +472,7 @@ Then load the bridge.yaml config file and start the talker to publish on the
 
 ```bash
 Shell B: (ROS1 only):
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 rosparam load bridge.yaml
@@ -449,7 +482,7 @@ rosrun rospy_tutorials talker
 
 ```bash
 Shell C: (ROS1 only):
-. /opt/ros/melodic/setup.bash
+source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 
@@ -460,7 +493,7 @@ Then, in a few ROS 2 terminals:
 
 ```bash
 # Shell D:
-. <install-space-with-ros2>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run ros1_bridge parameter_bridge
 ```
 
@@ -470,7 +503,7 @@ talker from ROS 2:
 
 ```bash
 # Shell E:
-. <install-space-with-ros2>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run demo_nodes_cpp listener
 ```
 
@@ -480,7 +513,7 @@ timestamp.
 
 ```bash
 # Shell F:
-. <install-space-with-ros2>/setup.bash
+source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run the following examples you will also need these ROS 1 packages:
 In order to make the examples below portable between versions of ROS, we define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`. 
 These are defined as the paths to the installation location of their respective ROS versions.
 
-If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
+If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` will be `/opt/ros/noetic`.
 
 Building the bridge as described below requires you to build all of ROS 2.
 We assume that you have downloaded it to `~/ros2_galactic`, and that is where you plan on building it.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ To run the following examples you will also need these ROS 1 packages:
 
 ### Prerequisites for the examples in this file
 
-In order to make the examples below portable between versions of ROS, we've chosen to define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`.  These are defined as the paths to the installation location of their respective ROS versions.
+In order to make the examples below portable between versions of ROS, we've chosen to define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`. 
+These are defined as the paths to the installation location of their respective ROS versions.
 
 If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_galactic/install`.
 
 If you've chosen to install either or both versions of ROS somewhere else, you will need adjust the definitions below to match your installation paths.
 
-Because these definitions are used continuously throughout this file, it would be useful to copy the following lines to your `.bashrc` file (if you're using `bash` as your shell).
+Because these definitions are used continuously throughout this page, it is useful to add the following lines to your shell startup file (`~/.bashrc` if you are using `bash`, `~/.zshrc` if you are using `zsh`).
 Modify these definitions as appropriate for the versions of ROS that you're using, and for the shell that you're using.
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To run the following examples you will also need these ROS 1 packages:
 
 ### Prerequisites for the examples in this file
 
-In order to make the examples below portable between versions of ROS, we've chosen to define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`. 
+In order to make the examples below portable between versions of ROS, we define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`. 
 These are defined as the paths to the installation location of their respective ROS versions.
 
 If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export ROS1_INSTALL_PATH=/opt/ros/noetic
 export ROS2_INSTALL_PATH=~/ros2_galactic/install
 ```
 
-As a note, there is no trailing '/' character in either definition.
+Note that no trailing '/' character is used in either definition.
 If you have problems involving paths, please verify that you have the correct path to the installation location, and that you do not have a trailing '/' in either definition.
 
 ### Building the bridge from source

--- a/README.md
+++ b/README.md
@@ -1,34 +1,20 @@
 # Bridge communication between ROS 1 and ROS 2
 
-This package provides a network bridge which enables the exchange of messages
-between ROS 1 and ROS 2.
+This package provides a network bridge which enables the exchange of messages between ROS 1 and ROS 2.
 
-The bridge is currently implemented in C++ as at the time the Python API for ROS
-2 had not been developed. Because of this its support is limited to only the
-message/service types available at compile time of the bridge. The bridge
-provided with the prebuilt ROS 2 binaries includes support for common ROS
-interfaces (messages/services), such as the interface packages listed in the
-[ros2/common_interfaces repository](https://github.com/ros2/common_interfaces)
-and `tf2_msgs`. See [the documentation](doc/index.rst) for more details on how
-ROS 1 and ROS 2 interfaces are associated with each other. If you would like to
-use a bridge with other interfaces (including your own custom types), you will
-have to build the bridge from source (instructions below), after building and
-sourcing your custom types in separate ROS 1 and ROS 2 workspaces. See
-[the documentation](doc/index.rst) for an example setup.
+The bridge is currently implemented in C++ as at the time the Python API for ROS 2 had not been developed.
+Because of this its support is limited to only the message/service types available at compile time of the bridge.
+The bridge provided with the prebuilt ROS 2 binaries includes support for common ROS interfaces (messages/services), such as the interface packages listed in the [ros2/common_interfaces repository](https://github.com/ros2/common_interfaces) and `tf2_msgs`.
+See [the documentation](doc/index.rst) for more details on how ROS 1 and ROS 2 interfaces are associated with each other.
+If you would like to use a bridge with other interfaces (including your own custom types), you will have to build the bridge from source (instructions below), after building and sourcing your custom types in separate ROS 1 and ROS 2 workspaces.
+See [the documentation](doc/index.rst) for an example setup.
 
-For efficiency reasons, topics will only be bridged when matching
-publisher-subscriber pairs are active for a topic on either side of the bridge.
-As a result using `ros2 topic echo <topic-name>` doesn't work but fails with an
-error message `Could not determine the type for the passed topic` if no other
-subscribers are present since the dynamic bridge hasn't bridged the topic yet.
-As a workaround the topic type can be specified explicitly `ros2 topic echo
-<topic-name> <topic-type>` which triggers the bridging of the topic since the
-`echo` command represents the necessary subscriber.  On the ROS 1 side `rostopic
-echo` doesn't have an option to specify the topic type explicitly. Therefore it
-can't be used with the dynamic bridge if no other subscribers are present. As
-an alternative you can use the `--bridge-all-2to1-topics` option to bridge all
-ROS 2 topics to ROS 1 so that tools such as `rostopic echo`, `rostopic list`
-and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
+For efficiency reasons, topics will only be bridged when matching publisher-subscriber pairs are active for a topic on either side of the bridge.
+As a result using `ros2 topic echo <topic-name>` doesn't work but fails with an error message `Could not determine the type for the passed topic` if no other subscribers are present since the dynamic bridge hasn't bridged the topic yet.
+As a workaround the topic type can be specified explicitly `ros2 topic echo <topic-name> <topic-type>` which triggers the bridging of the topic since the `echo` command represents the necessary subscriber.
+On the ROS 1 side `rostopic echo` doesn't have an option to specify the topic type explicitly.
+Therefore it can't be used with the dynamic bridge if no other subscribers are present.
+As an alternative you can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic echo`, `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
 ## Prerequisites
@@ -40,10 +26,8 @@ In order to run the bridge you need to either:
 
 After that you can run both examples described below.
 
-For all examples you need to source the environment of the install space where
-the bridge was built or unpacked to. Additionally you will need to either
-source the ROS 1 environment or at least set the `ROS_MASTER_URI` and run a
-`roscore`.
+For all examples you need to source the environment of the install space where the bridge was built or unpacked to.
+Additionally you will need to either source the ROS 1 environment or at least set the `ROS_MASTER_URI` and run a `roscore`.
 
 The following ROS 1 packages are required to build and use the bridge:
 * `catkin`
@@ -62,64 +46,46 @@ To run the following examples you will also need these ROS 1 packages:
 
 ### Prerequisites for the examples in this file
 
-In order to make the examples below portable between versions of ROS, we've
-chosen to define two environment variables, `ROS1_INSTALL_PATH` and
-`ROS2_INSTALL_PATH`.  These are defined as the paths to the installation
-location of their respective ROS versions.
+In order to make the examples below portable between versions of ROS, we've chosen to define two environment variables, `ROS1_INSTALL_PATH` and `ROS2_INSTALL_PATH`.  These are defined as the paths to the installation location of their respective ROS versions.
 
-If you installed Noetic in the default location, then the definition of
-`ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
+If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
 
-Building the bridge as described below requires you to build all of ROS 2. I
-assume that you have downloaded it to `~/ros2_galactic`, and that is where you
-plan on building it. In this case, `ROS2_INSTALL_PATH` will be defined as
-`~/ros2_galactic/install`.
+Building the bridge as described below requires you to build all of ROS 2. I assume that you have downloaded it to `~/ros2_galactic`, and that is where you plan on building it. In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_galactic/install`.
 
-If you've chosen to install either or both versions of ROS somewhere else, you
-will need adjust the definitions below to match your installation paths.
+If you've chosen to install either or both versions of ROS somewhere else, you will need adjust the definitions below to match your installation paths.
 
-Because these definitions are used continuously throughout this file, it would
-be useful to copy the following lines to your `.bashrc` file (if you're using
-`bash` as your shell).  Modify these definitions as appropriate for the
-versions of ROS that you're using, and for the shell that you're using.
+Because these definitions are used continuously throughout this file, it would be useful to copy the following lines to your `.bashrc` file (if you're using `bash` as your shell).  Modify these definitions as appropriate for the versions of ROS that you're using, and for the shell that you're using.
+
 
 ```bash
 export ROS1_INSTALL_PATH=/opt/ros/noetic
 export ROS2_INSTALL_PATH=~/ros2_galactic/install
 ```
 
-As a note, there is no trailing '/' character in either definition.  If you have
-problems involving paths, please verify that you have the correct path to the
-installation location, and that you do not have a trailing '/' in either
-definition.
+As a note, there is no trailing '/' character in either definition.  If you have problems involving paths, please verify that you have the correct path to the installation location, and that you do not have a trailing '/' in either definition.
 
 ### Building the bridge from source
 
-Before continuing you should have the prerequisites for building ROS 2 from
-source installed following
-[these instructions](https://github.com/ros2/ros2/wiki/Installation).
+Before continuing you should have the prerequisites for building ROS 2 from source installed following [these instructions](https://github.com/ros2/ros2/wiki/Installation).
 
-In the past, building this package required patches to ROS 1, but in the latest
-releases that is no longer the case. If you run into trouble first make sure
-you have at least version `1.11.16` of `ros_comm` and `rosbag`.
+In the past, building this package required patches to ROS 1, but in the latest releases that is no longer the case.
+If you run into trouble first make sure you have at least version `1.11.16` of `ros_comm` and `rosbag`.
 
-The bridge uses `pkg-config` to find ROS 1 packages. ROS 2 packages are found
-through CMake using `find_package()`. Therefore the `CMAKE_PREFIX_PATH` must
-not contain paths from ROS 1 which would overlay ROS 2 packages.
+The bridge uses `pkg-config` to find ROS 1 packages.
+ROS 2 packages are found through CMake using `find_package()`.
+Therefore the `CMAKE_PREFIX_PATH` must not contain paths from ROS 1 which would overlay ROS 2 packages.
 
 Here are the steps for Linux and OSX.
 
-You should first build everything but the ROS 1 bridge with normal colcon
-arguments. We don't recommend having your ROS 1 environment sourced during this
-step as it can add other libraries to the path.
+You should first build everything but the ROS 1 bridge with normal colcon arguments.
+We don't recommend having your ROS 1 environment sourced during this step as it can add other libraries to the path.
 
 
 ```bash
 colcon build --symlink-install --packages-skip ros1_bridge
 ```
 
-Next you need to source the ROS 1 environment, for Linux and ROS Melodic that
-would be:
+Next you need to source the ROS 1 environment.  If you set up the `ROS1_INSTALL_PATH` environment variable as described earlier, then the following will source the correct `setup.bash` file.
 
 
 ```bash
@@ -128,14 +94,10 @@ source ${ROS1_INSTALL_PATH}/setup.bash
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 ```
 
-The bridge will be built with support for any message/service packages that are
-on your path and have an associated mapping between ROS 1 and ROS 2. Therefore
-you must add any ROS 1 or ROS 2 workspaces that have message/service packages
-that you want to be bridged to your path before building the bridge. This can
-be done by adding explicit dependencies on the message/service packages to the
-`package.xml` of the bridge, so that `colcon` will add them to the path before
-it builds the bridge. Alternatively you can do it manually by sourcing the
-relevant workspaces yourself, e.g.:
+The bridge will be built with support for any message/service packages that are on your path and have an associated mapping between ROS 1 and ROS 2.
+Therefore you must add any ROS 1 or ROS 2 workspaces that have message/service packages that you want to be bridged to your path before building the bridge.
+This can be done by adding explicit dependencies on the message/service packages to the `package.xml` of the bridge, so that `colcon` will add them to the path before it builds the bridge.
+Alternatively you can do it manually by sourcing the relevant workspaces yourself, e.g.:
 
 
 ```bash
@@ -155,19 +117,16 @@ Then build just the ROS 1 bridge:
 colcon build --symlink-install --packages-select ros1_bridge --cmake-force-configure
 ```
 
-*Note:* If you are building on a memory constrained system you might want to
-limit the number of parallel jobs by setting e.g. the environment variable
-`MAKEFLAGS=-j1`.
+*Note:* If you are building on a memory constrained system you might want to limit the number of parallel jobs by setting e.g. the environment variable `MAKEFLAGS=-j1`.
 
 
 ## Example 1: run the bridge and the example talker and listener
 
-The talker and listener can be either a ROS 1 or a ROS 2 node. The bridge will
-pass the message along transparently.
+The talker and listener can be either a ROS 1 or a ROS 2 node.
+The bridge will pass the message along transparently.
 
-*Note:* When you are running these demos make sure to only source the indicated
-workspaces. You will get errors from most tools if they have both workspaces
-in their environment.
+*Note:* When you are running these demos make sure to only source the indicated workspaces.
+You will get errors from most tools if they have both workspaces in their environment.
 
 
 ### Example 1a: ROS 1 talker and ROS 2 listener
@@ -185,9 +144,8 @@ roscore
 
 ---
 
-Then we start the dynamic bridge which will watch the available ROS 1 and ROS 2
-topics. Once a *matching* topic has been detected it starts to bridge the
-messages on this topic.
+Then we start the dynamic bridge which will watch the available ROS 1 and ROS 2 topics.
+Once a *matching* topic has been detected it starts to bridge the messages on this topic.
 
 
 ```bash
@@ -204,8 +162,7 @@ export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```
 
-The program will start outputting the currently available topics in ROS 1 and
-ROS 2 in a regular interval.
+The program will start outputting the currently available topics in ROS 1 and ROS 2 in a regular interval.
 
 ---
 
@@ -235,17 +192,15 @@ ros2 run demo_nodes_cpp listener
 
 The ROS 2 node will start printing the received messages to the console.
 
-When looking at the output in *shell B* there will be a line stating that the
-bridge for this topic has been created:
+When looking at the output in *shell B* there will be a line stating that the bridge for this topic has been created:
 
 
 ```bash
 created 1to2 bridge for topic '/chatter' with ROS 1 type 'std_msgs/String' and ROS 2 type 'std_msgs/String'
 ```
 
-At the end stop all programs with `Ctrl-C`. Once you stop either the talker or
-the listener in *shell B* a line will be stating that the bridge has been torn
-down:
+At the end stop all programs with `Ctrl-C`.
+Once you stop either the talker or the listener in *shell B* a line will be stating that the bridge has been torn down:
 
 
 ```bash
@@ -259,8 +214,7 @@ The screenshot shows all the shell windows and their expected content:
 
 ### Example 1b: ROS 2 talker and ROS 1 listener
 
-The steps are very similar to the previous example and therefore only the
-commands are described.
+The steps are very similar to the previous example and therefore only the commands are described.
 
 
 ```bash
@@ -308,11 +262,9 @@ rosrun roscpp_tutorials listener
 
 ## Example 2: run the bridge and exchange images
 
-The second example will demonstrate the bridge passing along bigger and more
-complicated messages. A ROS 2 node is publishing images retrieved from a camera
-and on the ROS 1 side we use `rqt_image_view` to render the images in a GUI.
-And a ROS 1 publisher can send a message to toggle an option in the ROS 2
-node.
+The second example will demonstrate the bridge passing along bigger and more complicated messages.
+A ROS 2 node is publishing images retrieved from a camera and on the ROS 1 side we use `rqt_image_view` to render the images in a GUI.
+And a ROS 1 publisher can send a message to toggle an option in the ROS 2 node.
 
 First we start a ROS 1 `roscore` and the bridge:
 
@@ -355,17 +307,13 @@ source ${ROS2_INSTALL_PATH}/install/setup.bash
 ros2 run image_tools cam2image
 ```
 
-You should see the current images in `rqt_image_view` which are coming from the
-ROS 2 node `cam2image` and are being passed along by the bridge.
+You should see the current images in `rqt_image_view` which are coming from the ROS 2 node `cam2image` and are being passed along by the bridge.
 
 ---
 
-To exercise the bridge in the opposite direction at the same time you can
-publish a message to the ROS 2 node from ROS 1. By publishing either `true` or
-`false` to the `flip_image` topic, the camera node will conditionally flip the
-image before sending it. You can either use the `Message Publisher` plugin in
-`rqt` to publish a `std_msgs/Bool` message on the topic `flip_image`, or run
-one of the two following `rostopic` commands:
+To exercise the bridge in the opposite direction at the same time you can publish a message to the ROS 2 node from ROS 1.
+By publishing either `true` or `false` to the `flip_image` topic, the camera node will conditionally flip the image before sending it.
+You can either use the `Message Publisher` plugin in `rqt` to publish a `std_msgs/Bool` message on the topic `flip_image`, or run one of the two following `rostopic` commands:
 
 
 ```bash
@@ -377,8 +325,7 @@ rostopic pub -r 1 /flip_image std_msgs/Bool "{data: true}"
 rostopic pub -r 1 /flip_image std_msgs/Bool "{data: false}"
 ```
 
-The screenshot shows all the shell windows and their expected content (it was
-taken when Indigo was supported - you should use Melodic):
+The screenshot shows all the shell windows and their expected content (it was taken when Indigo was supported - you should use Melodic):
 
 ![ROS 2 camera and ROS 1 rqt](doc/ros2_camera_ros1_rqt.png)
 
@@ -388,16 +335,14 @@ In this example we will bridge a service TwoInts from
 [ros/roscpp_tutorials](https://github.com/ros/ros_tutorials) and AddTwoInts from
 [ros2/roscpp_examples](https://github.com/ros2/examples).
 
-While building, ros1_bridge looks for all installed ROS and ROS2 services. Found
-services are matched by comparing package name, service name and fields in a
-request and a response. If all names are the same in ROS and ROS2 service, the
-bridge will be created. It is also possible to pair services manually by
-creating a yaml file that will include names of corresponding services. You can
-find more information [here](doc/index.rst).
+While building, ros1_bridge looks for all installed ROS and ROS2 services.
+Found services are matched by comparing package name, service name and fields in a request and a response.
+If all names are the same in ROS and ROS2 service, the bridge will be created.
+It is also possible to pair services manually by creating a yaml file that will include names of corresponding services.
+You can find more information [here](doc/index.rst).
 
 So to make this example work, please make sure that the roscpp_tutorials package
-is installed on your system and the environment is set up correctly while you
-build ros1_bridge.
+is installed on your system and the environment is set up correctly while you build ros1_bridge.
 
 Launch ROS master
 
@@ -435,15 +380,10 @@ ros2 run demo_nodes_cpp add_two_ints_client
 ```
 
 ## Example 4: bridge only selected topics and services
-
-This example expands on example 3 by selecting a subset of topics and services
-to be bridged. This is handy when, for example, you have a system that runs
-most of it's stuff in either ROS 1 or ROS 2 but needs a few nodes from
-the 'opposite' version of ROS. Where the `dynamic_bridge` bridges all topics
-and service, the `parameter_bridge` uses the ROS 1 parameter server to choose
-which topics and services are bridged. For example, to bridge only eg. the
-`/chatter` topic and the `/add_two_ints service` from ROS1 to ROS2, create this
-configuration file, `bridge.yaml`:
+This example expands on example 3 by selecting a subset of topics and services to be bridged.
+This is handy when, for example, you have a system that runs most of it's stuff in either ROS 1 or ROS 2 but needs a few nodes from the 'opposite' version of ROS.
+Where the `dynamic_bridge` bridges all topics and service, the `parameter_bridge` uses the ROS 1 parameter server to choose which topics and services are bridged.
+For example, to bridge only eg. the `/chatter` topic and the `/add_two_ints service` from ROS1 to ROS2, create this configuration file, `bridge.yaml`:
 
 ```yaml
 topics:
@@ -467,8 +407,7 @@ source ${ROS1_INSTALL_PATH}/setup.bash
 roscore
 ```
 
-Then load the bridge.yaml config file and start the talker to publish on the
-`/chatter` topic:
+Then load the bridge.yaml config file and start the talker to publish on the `/chatter` topic:
 
 ```bash
 Shell B: (ROS1 only):
@@ -497,25 +436,18 @@ source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run ros1_bridge parameter_bridge
 ```
 
-If all is well, the logging shows it is creating bridges for the topic and
-service and you should be able to call the service and listen to the ROS 1
-talker from ROS 2:
+If all is well, the logging shows it is creating bridges for the topic and service and you should be able to call the service and listen to the ROS 1 talker from ROS 2:
 
 ```bash
 # Shell E:
 source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 run demo_nodes_cpp listener
 ```
-
-This should start printing text like `I heard: [hello world ...]` with a
-timestamp.
-
+This should start printing text like `I heard: [hello world ...]` with a timestamp.
 
 ```bash
 # Shell F:
 source ${ROS2_INSTALL_PATH}/setup.bash
 ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
 ```
-
-If all is well, the output should contain
-`example_interfaces.srv.AddTwoInts_Response(sum=3)`
+If all is well, the output should contain `example_interfaces.srv.AddTwoInts_Response(sum=3)`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ export ROS1_INSTALL_PATH=/opt/ros/noetic
 export ROS2_INSTALL_PATH=~/ros2_galactic/install
 ```
 
-As a note, there is no trailing '/' character in either definition.  If you have problems involving paths, please verify that you have the correct path to the installation location, and that you do not have a trailing '/' in either definition.
+As a note, there is no trailing '/' character in either definition.
+If you have problems involving paths, please verify that you have the correct path to the installation location, and that you do not have a trailing '/' in either definition.
 
 ### Building the bridge from source
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ These are defined as the paths to the installation location of their respective 
 
 If you installed Noetic in the default location, then the definition of `ROS1_INSTALL_PATH` would likely be `/opt/ros/noetic`.
 
-Building the bridge as described below requires you to build all of ROS 2. I assume that you have downloaded it to `~/ros2_galactic`, and that is where you plan on building it. In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_galactic/install`.
+Building the bridge as described below requires you to build all of ROS 2.
+We assume that you have downloaded it to `~/ros2_galactic`, and that is where you plan on building it.
+In this case, `ROS2_INSTALL_PATH` will be defined as `~/ros2_galactic/install`.
 
 If you've chosen to install either or both versions of ROS somewhere else, you will need adjust the definitions below to match your installation paths.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
 # Bridge communication between ROS 1 and ROS 2
 
-This package provides a network bridge which enables the exchange of messages between ROS 1 and ROS 2.
+This package provides a network bridge which enables the exchange of messages
+between ROS 1 and ROS 2.
 
-The bridge is currently implemented in C++ as at the time the Python API for ROS 2 had not been developed.
-Because of this its support is limited to only the message/service types available at compile time of the bridge.
-The bridge provided with the prebuilt ROS 2 binaries includes support for common ROS interfaces (messages/services), such as the interface packages listed in the [ros2/common_interfaces repository](https://github.com/ros2/common_interfaces) and `tf2_msgs`.
-See [the documentation](doc/index.rst) for more details on how ROS 1 and ROS 2 interfaces are associated with each other.
-If you would like to use a bridge with other interfaces (including your own custom types), you will have to build the bridge from source (instructions below), after building and sourcing your custom types in separate ROS 1 and ROS 2 workspaces.
-See [the documentation](doc/index.rst) for an example setup.
+The bridge is currently implemented in C++ as at the time the Python API for ROS
+2 had not been developed. Because of this its support is limited to only the
+message/service types available at compile time of the bridge. The bridge
+provided with the prebuilt ROS 2 binaries includes support for common ROS
+interfaces (messages/services), such as the interface packages listed in the
+[ros2/common_interfaces repository](https://github.com/ros2/common_interfaces)
+and `tf2_msgs`. See [the documentation](doc/index.rst) for more details on how
+ROS 1 and ROS 2 interfaces are associated with each other. If you would like to
+use a bridge with other interfaces (including your own custom types), you will
+have to build the bridge from source (instructions below), after building and
+sourcing your custom types in separate ROS 1 and ROS 2 workspaces. See
+[the documentation](doc/index.rst) for an example setup.
 
-For efficiency reasons, topics will only be bridged when matching publisher-subscriber pairs are active for a topic on either side of the bridge.
-As a result using `ros2 topic echo <topic-name>` doesn't work but fails with an error message `Could not determine the type for the passed topic` if no other subscribers are present since the dynamic bridge hasn't bridged the topic yet.
-As a workaround the topic type can be specified explicitly `ros2 topic echo <topic-name> <topic-type>` which triggers the bridging of the topic since the `echo` command represents the necessary subscriber.
-On the ROS 1 side `rostopic echo` doesn't have an option to specify the topic type explicitly.
-Therefore it can't be used with the dynamic bridge if no other subscribers are present.
-As an alternative you can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic echo`, `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
+For efficiency reasons, topics will only be bridged when matching
+publisher-subscriber pairs are active for a topic on either side of the bridge.
+As a result using `ros2 topic echo <topic-name>` doesn't work but fails with an
+error message `Could not determine the type for the passed topic` if no other
+subscribers are present since the dynamic bridge hasn't bridged the topic yet.
+As a workaround the topic type can be specified explicitly `ros2 topic echo
+<topic-name> <topic-type>` which triggers the bridging of the topic since the
+`echo` command represents the necessary subscriber.  On the ROS 1 side `rostopic
+echo` doesn't have an option to specify the topic type explicitly. Therefore it
+can't be used with the dynamic bridge if no other subscribers are present. As
+an alternative you can use the `--bridge-all-2to1-topics` option to bridge all
+ROS 2 topics to ROS 1 so that tools such as `rostopic echo`, `rostopic list`
+and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
 ## Prerequisites
@@ -26,8 +40,10 @@ In order to run the bridge you need to either:
 
 After that you can run both examples described below.
 
-For all examples you need to source the environment of the install space where the bridge was built or unpacked to.
-Additionally you will need to either source the ROS 1 environment or at least set the `ROS_MASTER_URI` and run a `roscore`.
+For all examples you need to source the environment of the install space where
+the bridge was built or unpacked to. Additionally you will need to either
+source the ROS 1 environment or at least set the `ROS_MASTER_URI` and run a
+`roscore`.
 
 The following ROS 1 packages are required to build and use the bridge:
 * `catkin`
@@ -46,25 +62,32 @@ To run the following examples you will also need these ROS 1 packages:
 
 ### Building the bridge from source
 
-Before continuing you should have the prerequisites for building ROS 2 from source installed following [these instructions](https://github.com/ros2/ros2/wiki/Installation).
+Before continuing you should have the prerequisites for building ROS 2 from
+source installed following
+[these instructions](https://github.com/ros2/ros2/wiki/Installation).
 
-In the past, building this package required patches to ROS 1, but in the latest releases that is no longer the case.
-If you run into trouble first make sure you have at least version `1.11.16` of `ros_comm` and `rosbag`.
+In the past, building this package required patches to ROS 1, but in the latest
+releases that is no longer the case. If you run into trouble first make sure
+you have at least version `1.11.16` of `ros_comm` and `rosbag`.
 
-The bridge uses `pkg-config` to find ROS 1 packages.
-ROS 2 packages are found through CMake using `find_package()`.
-Therefore the `CMAKE_PREFIX_PATH` must not contain paths from ROS 1 which would overlay ROS 2 packages.
+The bridge uses `pkg-config` to find ROS 1 packages. ROS 2 packages are found
+through CMake using `find_package()`. Therefore the `CMAKE_PREFIX_PATH` must
+not contain paths from ROS 1 which would overlay ROS 2 packages.
 
 Here are the steps for Linux and OSX.
 
-You should first build everything but the ROS 1 bridge with normal colcon arguments.
-We don't recommend having your ROS 1 environment sourced during this step as it can add other libraries to the path.
+You should first build everything but the ROS 1 bridge with normal colcon
+arguments. We don't recommend having your ROS 1 environment sourced during this
+step as it can add other libraries to the path.
+
 
 ```
 colcon build --symlink-install --packages-skip ros1_bridge
 ```
 
-Next you need to source the ROS 1 environment, for Linux and ROS Melodic that would be:
+Next you need to source the ROS 1 environment, for Linux and ROS Melodic that
+would be:
+
 
 ```
 source /opt/ros/melodic/setup.bash
@@ -72,10 +95,15 @@ source /opt/ros/melodic/setup.bash
 # . ~/ros_catkin_ws/install_isolated/setup.bash
 ```
 
-The bridge will be built with support for any message/service packages that are on your path and have an associated mapping between ROS 1 and ROS 2.
-Therefore you must add any ROS 1 or ROS 2 workspaces that have message/service packages that you want to be bridged to your path before building the bridge.
-This can be done by adding explicit dependencies on the message/service packages to the `package.xml` of the bridge, so that `colcon` will add them to the path before it builds the bridge.
-Alternatively you can do it manually by sourcing the relevant workspaces yourself, e.g.:
+The bridge will be built with support for any message/service packages that are
+on your path and have an associated mapping between ROS 1 and ROS 2. Therefore
+you must add any ROS 1 or ROS 2 workspaces that have message/service packages
+that you want to be bridged to your path before building the bridge. This can
+be done by adding explicit dependencies on the message/service packages to the
+`package.xml` of the bridge, so that `colcon` will add them to the path before
+it builds the bridge. Alternatively you can do it manually by sourcing the
+relevant workspaces yourself, e.g.:
+
 
 ```
 # You have already sourced your ROS installation.
@@ -89,25 +117,30 @@ Alternatively you can do it manually by sourcing the relevant workspaces yoursel
 
 Then build just the ROS 1 bridge:
 
+
 ```
 colcon build --symlink-install --packages-select ros1_bridge --cmake-force-configure
 ```
 
-*Note:* If you are building on a memory constrained system you might want to limit the number of parallel jobs by setting e.g. the environment variable `MAKEFLAGS=-j1`.
+*Note:* If you are building on a memory constrained system you might want to
+limit the number of parallel jobs by setting e.g. the environment variable
+`MAKEFLAGS=-j1`.
 
 
 ## Example 1: run the bridge and the example talker and listener
 
-The talker and listener can be either a ROS 1 or a ROS 2 node.
-The bridge will pass the message along transparently.
+The talker and listener can be either a ROS 1 or a ROS 2 node. The bridge will
+pass the message along transparently.
 
-*Note:* When you are running these demos make sure to only source the indicated workspaces.
-You will get errors from most tools if they have both workspaces in their environment.
+*Note:* When you are running these demos make sure to only source the indicated
+workspaces. You will get errors from most tools if they have both workspaces
+in their environment.
 
 
 ### Example 1a: ROS 1 talker and ROS 2 listener
 
 First we start a ROS 1 `roscore`:
+
 
 ```
 # Shell A (ROS 1 only):
@@ -119,8 +152,10 @@ roscore
 
 ---
 
-Then we start the dynamic bridge which will watch the available ROS 1 and ROS 2 topics.
-Once a *matching* topic has been detected it starts to bridge the messages on this topic.
+Then we start the dynamic bridge which will watch the available ROS 1 and ROS 2
+topics. Once a *matching* topic has been detected it starts to bridge the
+messages on this topic.
+
 
 ```
 # Shell B (ROS 1 + ROS 2):
@@ -136,11 +171,13 @@ export ROS_MASTER_URI=http://localhost:11311
 ros2 run ros1_bridge dynamic_bridge
 ```
 
-The program will start outputting the currently available topics in ROS 1 and ROS 2 in a regular interval.
+The program will start outputting the currently available topics in ROS 1 and
+ROS 2 in a regular interval.
 
 ---
 
 Now we start the ROS 1 talker.
+
 
 ```
 # Shell C:
@@ -156,6 +193,7 @@ The ROS 1 node will start printing the published messages to the console.
 
 Now we start the ROS 2 listener from the `demo_nodes_cpp` ROS 2 package.
 
+
 ```
 # Shell D:
 . <install-space-with-ros2>/setup.bash
@@ -164,14 +202,18 @@ ros2 run demo_nodes_cpp listener
 
 The ROS 2 node will start printing the received messages to the console.
 
-When looking at the output in *shell B* there will be a line stating that the bridge for this topic has been created:
+When looking at the output in *shell B* there will be a line stating that the
+bridge for this topic has been created:
+
 
 ```
 created 1to2 bridge for topic '/chatter' with ROS 1 type 'std_msgs/String' and ROS 2 type 'std_msgs/String'
 ```
 
-At the end stop all programs with `Ctrl-C`.
-Once you stop either the talker or the listener in *shell B* a line will be stating that the bridge has been torn down:
+At the end stop all programs with `Ctrl-C`. Once you stop either the talker or
+the listener in *shell B* a line will be stating that the bridge has been torn
+down:
+
 
 ```
 removed 1to2 bridge for topic '/chatter'
@@ -184,7 +226,9 @@ The screenshot shows all the shell windows and their expected content:
 
 ### Example 1b: ROS 2 talker and ROS 1 listener
 
-The steps are very similar to the previous example and therefore only the commands are described.
+The steps are very similar to the previous example and therefore only the
+commands are described.
+
 
 ```
 # Shell A:
@@ -195,6 +239,7 @@ roscore
 ```
 
 ---
+
 
 ```
 # Shell B:
@@ -228,12 +273,13 @@ Now we start the ROS 1 listener.
 rosrun roscpp_tutorials listener
 ```
 
-
 ## Example 2: run the bridge and exchange images
 
-The second example will demonstrate the bridge passing along bigger and more complicated messages.
-A ROS 2 node is publishing images retrieved from a camera and on the ROS 1 side we use `rqt_image_view` to render the images in a GUI.
-And a ROS 1 publisher can send a message to toggle an option in the ROS 2 node.
+The second example will demonstrate the bridge passing along bigger and more
+complicated messages. A ROS 2 node is publishing images retrieved from a camera
+and on the ROS 1 side we use `rqt_image_view` to render the images in a GUI.
+And a ROS 1 publisher can send a message to toggle an option in the ROS 2
+node.
 
 First we start a ROS 1 `roscore` and the bridge:
 
@@ -267,7 +313,7 @@ Now we start the ROS 1 GUI:
 rqt_image_view /image
 ```
 
---
+---
 
 Now we start the ROS 2 image publisher from the `image_tools` ROS 2 package:
 ```
@@ -276,13 +322,18 @@ Now we start the ROS 2 image publisher from the `image_tools` ROS 2 package:
 ros2 run image_tools cam2image
 ```
 
-You should see the current images in `rqt_image_view` which are coming from the ROS 2 node `cam2image` and are being passed along by the bridge.
+You should see the current images in `rqt_image_view` which are coming from the
+ROS 2 node `cam2image` and are being passed along by the bridge.
 
---
+---
 
-To exercise the bridge in the opposite direction at the same time you can publish a message to the ROS 2 node from ROS 1.
-By publishing either `true` or `false` to the `flip_image` topic, the camera node will conditionally flip the image before sending it.
-You can either use the `Message Publisher` plugin in `rqt` to publish a `std_msgs/Bool` message on the topic `flip_image`, or run one of the two following `rostopic` commands:
+To exercise the bridge in the opposite direction at the same time you can
+publish a message to the ROS 2 node from ROS 1. By publishing either `true` or
+`false` to the `flip_image` topic, the camera node will conditionally flip the
+image before sending it. You can either use the `Message Publisher` plugin in
+`rqt` to publish a `std_msgs/Bool` message on the topic `flip_image`, or run
+one of the two following `rostopic` commands:
+
 
 ```
 # Shell E:
@@ -293,7 +344,8 @@ rostopic pub -r 1 /flip_image std_msgs/Bool "{data: true}"
 rostopic pub -r 1 /flip_image std_msgs/Bool "{data: false}"
 ```
 
-The screenshot shows all the shell windows and their expected content (it was taken when Indigo was supported - you should use Melodic):
+The screenshot shows all the shell windows and their expected content (it was
+taken when Indigo was supported - you should use Melodic):
 
 ![ROS 2 camera and ROS 1 rqt](doc/ros2_camera_ros1_rqt.png)
 
@@ -303,14 +355,16 @@ In this example we will bridge a service TwoInts from
 [ros/roscpp_tutorials](https://github.com/ros/ros_tutorials) and AddTwoInts from
 [ros2/roscpp_examples](https://github.com/ros2/examples).
 
-While building, ros1_bridge looks for all installed ROS and ROS2 services.
-Found services are matched by comparing package name, service name and fields in a request and a response.
-If all names are the same in ROS and ROS2 service, the bridge will be created.
-It is also possible to pair services manually by creating a yaml file that will include names of corresponding services.
-You can find more information [here](doc/index.rst).
+While building, ros1_bridge looks for all installed ROS and ROS2 services. Found
+services are matched by comparing package name, service name and fields in a
+request and a response. If all names are the same in ROS and ROS2 service, the
+bridge will be created. It is also possible to pair services manually by
+creating a yaml file that will include names of corresponding services. You can
+find more information [here](doc/index.rst).
 
 So to make this example work, please make sure that the roscpp_tutorials package
-is installed on your system and the environment is set up correctly while you build ros1_bridge.
+is installed on your system and the environment is set up correctly while you
+build ros1_bridge.
 
 Launch ROS master
 
@@ -348,10 +402,15 @@ ros2 run demo_nodes_cpp add_two_ints_client
 ```
 
 ## Example 4: bridge only selected topics and services
-This example expands on example 3 by selecting a subset of topics and services to be bridged.
-This is handy when, for example, you have a system that runs most of it's stuff in either ROS 1 or ROS 2 but needs a few nodes from the 'opposite' version of ROS.
-Where the `dynamic_bridge` bridges all topics and service, the `parameter_bridge` uses the ROS 1 parameter server to choose which topics and services are bridged.
-For example, to bridge only eg. the `/chatter` topic and the `/add_two_ints service` from ROS1 to ROS2, create this configuration file, `bridge.yaml`:
+
+This example expands on example 3 by selecting a subset of topics and services
+to be bridged. This is handy when, for example, you have a system that runs
+most of it's stuff in either ROS 1 or ROS 2 but needs a few nodes from
+the 'opposite' version of ROS. Where the `dynamic_bridge` bridges all topics
+and service, the `parameter_bridge` uses the ROS 1 parameter server to choose
+which topics and services are bridged. For example, to bridge only eg. the
+`/chatter` topic and the `/add_two_ints service` from ROS1 to ROS2, create this
+configuration file, `bridge.yaml`:
 
 ```yaml
 topics:
@@ -375,7 +434,8 @@ Start a ROS 1 roscore:
 roscore
 ```
 
-Then load the bridge.yaml config file and start the talker to publish on the `/chatter` topic:
+Then load the bridge.yaml config file and start the talker to publish on the
+`/chatter` topic:
 
 ```bash
 Shell B: (ROS1 only):
@@ -404,18 +464,25 @@ Then, in a few ROS 2 terminals:
 ros2 run ros1_bridge parameter_bridge
 ```
 
-If all is well, the logging shows it is creating bridges for the topic and service and you should be able to call the service and listen to the ROS 1 talker from ROS 2:
+If all is well, the logging shows it is creating bridges for the topic and
+service and you should be able to call the service and listen to the ROS 1
+talker from ROS 2:
 
 ```bash
 # Shell E:
 . <install-space-with-ros2>/setup.bash
 ros2 run demo_nodes_cpp listener
 ```
-This should start printing text like `I heard: [hello world ...]` with a timestamp.
+
+This should start printing text like `I heard: [hello world ...]` with a
+timestamp.
+
 
 ```bash
 # Shell F:
 . <install-space-with-ros2>/setup.bash
 ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
 ```
-If all is well, the output should contain `example_interfaces.srv.AddTwoInts_Response(sum=3)`
+
+If all is well, the output should contain
+`example_interfaces.srv.AddTwoInts_Response(sum=3)`

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -406,7 +406,7 @@ void get_ros1_service_info(
       transport->close();
     });
   if (!transport->connect(host, port)) {
-    fprintf(stderr, "Failed to connect to %s:%d\n", host.data(), port);
+    fprintf(stderr, "Failed to connect to %s (%s:%d)\n", name.data(), host.data(), port);
     return;
   }
   ros::M_string header_out;


### PR DESCRIPTION
I noticed that the README.md file had a number of minor issues that meant that it wasn't as clear as it could be.  This PR clears them up.

### Issues

- I rewrapped all lines to 80 columns.  This makes it a little easier to read in a text editor.
- I added `bash` as the [info string](https://github.github.com/gfm/#info-string) of every fenced code block.  This makes Github render the blocks correctly, and makes copying simpler.
- I added two new environment variables to the prerequisites.  These are `ROS1_INSTALL_PATH`, and `ROS2_INSTALL_PATH`.  They exist to make it simple to run the scripts regardless of which versions of ROS 1 and 2 are currently in use.  Instructions on how to set them are given within the README.md