### PR TITLE
Make sure to use fully-qualified boost placeholders.

### DIFF
--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -100,7 +100,7 @@ public:
       new ros::SubscriptionCallbackHelperT<const ros::MessageEvent<ROS1_T const> &>(
         boost::bind(
           &Factory<ROS1_T, ROS2_T>::ros1_callback,
-          _1, ros2_pub, ros1_type_name_, ros2_type_name_, logger)));
+          boost::placeholders::_1, ros2_pub, ros1_type_name_, ros2_type_name_, logger)));
     return node.subscribe(ops);
   }
 

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>rosidl_parser</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
+  <build_depend>libboost-dev</build_depend>
   <build_depend>pkg-config</build_depend>
   <build_depend>python3-yaml</build_depend>
   <build_depend>rclcpp</build_depend>


### PR DESCRIPTION
Also make sure to declare a direct dependency on boost.
While we are always getting it from ROS 1, this code directly
uses it and so should also declare a dependency.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I recently attempted to build the ros1_bridge against the ROS (1) packages available directly in Ubuntu Jammy.  This is the only thing that prevented me from doing so, and is an obvious fix anyway.