### PR TITLE
Suppress warning when packages aren't available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ if(NOT PKG_CONFIG_FOUND)
 endif()
 
 find_ros1_package(roscpp)
-if(NOT ros1_roscpp_FOUND) 
-  if (NOT ROS1_PACKAGES_UNAVAILABLE)
+if(NOT ros1_roscpp_FOUND)
+  if(NOT ROS1_PACKAGES_UNAVAILABLE)
     # Only warn if ROS1 packages were expected to be available
     message(WARNING "Failed to find ROS 1 roscpp, skipping...")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,11 @@ if(NOT PKG_CONFIG_FOUND)
 endif()
 
 find_ros1_package(roscpp)
-if(NOT ros1_roscpp_FOUND)
-  message(WARNING "Failed to find ROS 1 roscpp, skipping...")
+if(NOT ros1_roscpp_FOUND) 
+  if (NOT ROS1_PACKAGES_UNAVAILABLE)
+    # Only warn if ROS1 packages were expected to be available
+    message(WARNING "Failed to find ROS 1 roscpp, skipping...")
+  endif()
   # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
   ament_package(
     CONFIG_EXTRAS ${cmake_extras_files}


### PR DESCRIPTION
ROS1 packages aren't available on all platforms.  In order to keep
ros1_bridge in ros2.repos without warnings turning CI yellow, we need to
suppress this warning.

This is an alternative to https://github.com/ros2/ros2/pull/1256

This will require packing CI jobs to be updated with a new cmake arg `-DROS1_PACKAGES_UNAVAILABLE=true` for Jammy jobs.

```
$ colcon build --packages-select ros1_bridge
Starting >>> ros1_bridge
--- stderr: ros1_bridge                           
CMake Warning at CMakeLists.txt:36 (message):
  Failed to find ROS 1 roscpp, skipping...


---
Finished <<< ros1_bridge [2.30s]
```

vs 

```
colcon build --packages-select ros1_bridge --cmake-args -DROS1_PACKAGES_UNAVAILABLE=1
Starting >>> ros1_bridge
Finished <<< ros1_bridge [2.36s]                  

Summary: 1 package finished [3.37s]
```


Signed-off-by: Michael Carroll <michael@openrobotics.org>