### PR TITLE
to correct Examples 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,10 +397,10 @@ topics:
     topic: /chatter  # ROS1 topic name
     type: std_msgs/msg/String  # ROS2 type name
     queue_size: 1  # For the publisher back to ROS1
-services_1_to_2:
+services_2_to_1:
   -
-    service: /add_two_ints  # ROS1 service name
-    type: example_interfaces/srv/AddTwoInts  # The ROS2 type name
+    service: /add_two_ints  # ROS2 service name
+    type: roscpp_tutorials/TwoInts  # The ROS1 type name
 ```
 
 Start a ROS 1 roscore:


### PR DESCRIPTION
I have tested it.

terminal 1
<pre>
ros2 run ros1_bridge parameter_bridge
Trying to create bidirectional bridge for topic '/chatter' with ROS 2 type 'std_msgs/msg/String'
[INFO] [1651472131.323351466] [ros_bridge]: create bidirectional bridge for topic /chatter
The parameter 'services_1_to_2' either doesn't exist or isn't an array
Trying to create bridge for ROS 1 service '/add_two_ints' with type 'roscpp_tutorials/TwoInts'
Created 2 to 1 bridge for service /add_two_ints
[INFO] [1651472131.772500582] [ros_bridge]: Passing message from ROS 1 std_msgs/String to ROS 2 std_msgs/msg/String (showing msg only once per type)
</pre>

terminal 2
<pre>
$ rosrun roscpp_tutorials add_two_ints_server
[ INFO] [1651472257.007540349]: request: x=1, y=2
[ INFO] [1651472257.010445376]:   sending back response: [3]
</pre>

terminal 3
<pre>
$ ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 1, b: 2}"
requester: making request: example_interfaces.srv.AddTwoInts_Request(a=1, b=2)

response:
example_interfaces.srv.AddTwoInts_Response(sum=3)


</pre>