### PR TITLE
Clarify README (Example 4 and parameter bridge service directionality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,18 +389,19 @@ ros2 run demo_nodes_cpp add_two_ints_client
 This example expands on example 3 by selecting a subset of topics and services to be bridged.
 This is handy when, for example, you have a system that runs most of it's stuff in either ROS 1 or ROS 2 but needs a few nodes from the 'opposite' version of ROS.
 Where the `dynamic_bridge` bridges all topics and service, the `parameter_bridge` uses the ROS 1 parameter server to choose which topics and services are bridged.
-For example, to bridge only eg. the `/chatter` topic and the `/add_two_ints service` from ROS1 to ROS2, create this configuration file, `bridge.yaml`:
+**Note**: The service bridge is **monodirectional**. You must use either `services_2_to_1` and/or `services_1_or_2` to bridge ROS 2 -> ROS 1 or ROS 1 -> ROS 2 services accordingly.
+For example, to bridge only the `/chatter` topic bidirectionally, and the `/add_two_ints service` from ROS 2 to ROS 1 only, create this configuration file, `bridge.yaml`:
 
 ```yaml
 topics:
   -
-    topic: /chatter  # ROS1 topic name
-    type: std_msgs/msg/String  # ROS2 type name
-    queue_size: 1  # For the publisher back to ROS1
+    topic: /chatter  # Topic name on both ROS 1 and ROS 2
+    type: std_msgs/msg/String  # Type of topic to bridge
+    queue_size: 1  # Queue size
 services_2_to_1:
   -
-    service: /add_two_ints  # ROS2 service name
-    type: roscpp_tutorials/TwoInts  # The ROS1 type name
+    service: /add_two_ints  # ROS 1 service name
+    type: roscpp_tutorials/TwoInts  # The ROS 1 service type name
 ```
 
 Start a ROS 1 roscore:
@@ -416,7 +417,7 @@ roscore
 Then load the bridge.yaml config file and start the talker to publish on the `/chatter` topic:
 
 ```bash
-Shell B: (ROS1 only):
+Shell B: (ROS 1 only):
 source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash
@@ -426,7 +427,7 @@ rosrun rospy_tutorials talker
 ```
 
 ```bash
-Shell C: (ROS1 only):
+Shell C: (ROS 1 only):
 source ${ROS1_INSTALL_PATH}/setup.bash
 # Or, on OSX, something like:
 # . ~/ros_catkin_ws/install_isolated/setup.bash


### PR DESCRIPTION
https://github.com/ros2/ros1_bridge/issues/356 highlighted an error in the README that probably arose from the fact that the service parameter bridge is monodirectional. This PR aims to fix that by adding a clarificatory note.

Also, the comments in the example `yaml` file were updated, and some minor ROS1/2 formatting was done.