### PR TITLE
Fix array static_assertion with newer compilers

### DIFF
--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -157,7 +157,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
 @[      else]@
   // statically sized array
   static_assert(
-    (ros2_msg.@(ros2_field_selection).size()) >= (ros1_msg.@(ros1_field_selection).size()),
+    std::tuple_size<decltype(ros2_msg.@(ros2_field_selection))>::value >= (ros1_msg.@(ros1_field_selection).static_size),
     "destination array not large enough for source array"
   );
 @[      end if]@
@@ -244,7 +244,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
 @[      else]@
   // statically sized array
   static_assert(
-    (ros1_msg.@(ros1_field_selection).size()) >= (ros2_msg.@(ros2_field_selection).size()),
+    (ros1_msg.@(ros1_field_selection).static_size) >= std::tuple_size<decltype(ros2_msg.@(ros2_field_selection))>::value,
     "destination array not large enough for source array"
   );
 @[      end if]@


### PR DESCRIPTION
As reported in #313, `ros1_bridge` can not successfully build with newer versions of GCC (such as 11.2.0 on Ubuntu Jammy).

This is one alternative which uses `std::tuple_size` on ROS 2's `std::array` (https://en.cppreference.com/w/cpp/container/array/tuple_size), and uses `static_size` from ROS 1's `boost::array` members. 

Here is an example in Compiler Explorer to demonstrate the methodology:  [example](https://godbolt.org/#z:OYLghAFBqd5TKALEBjA9gEwKYFFMCWALugE4A0BIEAZgQDbYB2AhgLbYgDkAjF%2BTXRMiAZVQtGIHgBYBQogFUAztgAKAD24AGfgCsp5eiyahUAUgBMAIUtXyKxqiIEh1ZpgDC6egFc2TEAAOcncAGQImbAA5PwAjbFIQAGYecgAHdCViFyYvX38g9MzsoXDImLZ4xJT7bEdnIREiFlIiPL8A4IdsJxymlqIy6LiE5NSlZtb2gq7JwYjhytGUgEp7dB9SVE4uSySI1F8cAGozJI8W0hYATzPcMy0AQT2Do%2BxT85cJ0mx2O4fnk8XkxDj4TmcPLF0JkiAB6S43AB0SDSaX%2BQKe3x8TmOAFlsEolCxgNgACrXNLYAD6ACUAPIiCynADsNiexw5xwmmBAIARt3OmA2sUY5GOSQAbHdjhgAG4tAjGbZnNnPZkAERVAIBWJx%2BMJxLJFOp9JEPBZqs5xyhMN5/IhQp8IuwYsl0rlCqV2C1QI1PsBAYiRGObBYEQgQeOLWAqDFqCQLQAVImo6RgLKVtrWQCrbDYVzms5UFSWISEkQIPqiSTyZTeR7SIqQdhEVkAF7YCArD6apLq8USzMYx5WquG2smhnmthEHj%2Bq0TFhFktl1oQGc8RENpvbVsEDtdntnfuSzNJS2cxfL0sqNft7DoGjr2db9Dyxte7vH48D44pwJnheHJXgQxY3uWz6btuXqtoWoFUveR59gOgE5pyebHOq6AEkwYBcMGADuZAANZRkoxxEEgCTvAQ5FMOgBY8iARA%2BGkjAIfu7xKJSqCKvQ%2B5LjkxyCKQ1rQhMdqkFctzsuh%2BYgWBq4VtyvIsWx1L3g6PT0EQxqQa%2B747tgZ64Ly8q%2BO837Iae/rarJHJjjWxq0gyTIzhY86XnBim3hW7kGZ6zZ7geX59j%2BNnnmhwHeSuvkQPej7PhYAUfs2oW9ieEp/scAGeRyGFYTheGESRYqUdRxy0cc9EFoJxaIRwSykFFxwYQpsUQf50FBe1iFWZlqH2bV15KfFRBMWp7GaYK2m6ZSSUpUZJlmRIPiWWF1mDrZfrDgCXBrPQ3AAKz8AEXA6OQ6DcB4ti2FyGxbJZFgpPwRDaPtazEckSSIkkf3/QDAMSoY3DSKd72Xdw/BKCAWjkG9537eQcCwCgGBsGkDAJJQ1Do5jjCJMAACcsh0DpCQwxAsTcHw5CxBELTXDT/Doxwwh0kw9BM7w/A4KGJiSIj5CED8vSygSzMhOoPQ%2BEQOwXUGdQQ/xsRXKQ1xeDgktEI2bDM2sNBGMASgAGoENgBF0pSZ204IwhiBInAyHIwjKGomhC/oqRGCYaC3dYhgELEMOwKwHAgDaEzkOLiS8BKzIfZdaQNEwMNcAAtNyx7mNYtg8AntT1DkbhMJ43gdAYYQLBUVQGBkWQp9MASpPXJRMEMNejOMdQ9Cn/RTOXBTd0XjRzB3IyJOMcxNwYi6tOPTVSGsSgPdsBg69gOx8Adx3g0LV1cOogQSunErSMcMaoMcROIufEA3bnAfHPgxBkKcz2pMcXgY1jol7DwKxXrvRWJ9b6v1AYQL%2BsDQ6XAwbkDOhdA%2B0NYbw2AcjRAEA0boB/gTHGEA8a/xAMAHgPALACAYHLUglNqY8zpgzdWktWbMCIBzLmks%2BbGGAILC6Ite4EHFmnWm2BpaoFlvLfgisYEXRVmrDWWAt6vV1vrAQRtTbm0ttbSWdtRDiEkM7bRbsNAQ30GQn2ph/Z2BViHKAYdOCRyINHUYccE4gKTinNO0Me69FcBAdwM9UhV3KBPOuxRG6D2bkUBuOQF612Hnw0eAx/GF3iUwfu8wgmLynok8Js8x7V2CQA9Ymw16pA3goneXATrwIhgfI%2BJ8z4X1QFfEhiImT3wsWKF%2BJA/4fzFN/fGCR35JAsIA1BiNXFfT%2BuAyBgMQawL3ogqG9gUEIx0K4mBFh%2BB6yOnDBB/AkFjLWeg%2BAmCQAbCIGkWWeDsCEG6QQHkqRtEOz0aTeQhiPYXS9uQAiVw0jKJgVUvZkMuB0llpc4Mj5jh1NPufS%2B19b7HHvtggZPTVhAPGWsKiLAcCJC7HMuB2zdk1KWTDOGqzE4wKSAs/ZSzyWuJjlkVw0ggA%3D%3D%3D)
Signed-off-by: Michael Carroll <michael@openrobotics.org>