### PR TITLE
Fixed index for ros2 namespace type messages

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -959,8 +959,8 @@ class MessageIndex:
         """
         Get Message from ROS 2 index.
 
-        :type field: rosidl_adapter.parser.Field
-        :return: the message indexed for the fields `type.pkg_name` and
-        `type.type` of `field`
+        :type field: rosidl_parser.parser.NamespacedType
+        :return: the message indexed for the fields `type.namespaces[0]` and
+        `type.name` of `field`
         """
-        return self._ros2_idx[(field.type.pkg_name, field.type.type)]
+        return self._ros2_idx[(field.type.namespaces[0], field.type.name)]

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -959,7 +959,7 @@ class MessageIndex:
         """
         Get Message from ROS 2 index.
 
-        :type field: rosidl_parser.parser.NamespacedType
+        :type field: rosidl_parser.definition.NamespacedType
         :return: the message indexed for the fields `type.namespaces[0]` and
         `type.name` of `field`
         """


### PR DESCRIPTION
As reported in #354 bridge fails when ros2 message uses standard namespaces (std_msgs, geometry_msgs, etc.) to be mapped with  ros1 messages. Note: this works as expected when no namespaces are used on ros2 side, regardless of what's on ros1 side.

It was failing while returning package name and message name parsed from a `rosidl_parser.definition.NamespacedType` object. Type field was incorrect, seems to be using `rosidl_parser` for messages and `rosidl_adapter` for services, as far as my understanding. Updated the function description too.
