### PR TITLE
Move xmlrpcpp find_package so it only searches if ROS 1 is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(xmlrpcpp REQUIRED)
 
 # find ROS 1 packages
 set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
@@ -44,6 +43,10 @@ if(NOT ros1_roscpp_FOUND)
 endif()
 
 find_ros1_package(std_msgs REQUIRED)
+
+# Dependency that we should only look for if ROS 1 is installed (it's not present on a ROS 2
+# system; see https://github.com/ros2/ros1_bridge/pull/331#issuecomment-1188111510)
+find_package(xmlrpcpp REQUIRED)
 
 # find ROS 1 packages with messages / services
 include(cmake/find_ros1_interface_packages.cmake)


### PR DESCRIPTION
This PR makes the `xmlrpcpp` dependency search only occur if ROS 1 is found. This is because on a system with only ROS 2 installed, `xmlrpcpp` might not be installed, leading to the build of `ros1_bridge` failing for an unexpected (by the user) reason.

For more info, see this comment: https://github.com/ros2/ros1_bridge/pull/331#issuecomment-1188111510