### PR TITLE
Provide direct serialization of ROS2 messsage to ROS1 streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,27 +91,27 @@ if(BUILD_TESTING)
   if(ros1_geometry_msgs_FOUND AND ros1_sensor_msgs_FOUND AND ros1_std_msgs_FOUND)
     ament_add_gtest(test_convert_generic test/test_convert_generic.cpp)
     ament_target_dependencies(test_convert_generic
+      "geometry_msgs"
+      "rclcpp"
       "ros1_roscpp"
       "ros1_sensor_msgs"
       "ros1_std_msgs"
       "ros1_geometry_msgs"
       "sensor_msgs"
       "std_msgs"
-      "geometry_msgs"
-      "rclcpp"
     )
     target_link_libraries(test_convert_generic ${PROJECT_NAME})
 
     ament_add_gtest(test_ros2_to_ros1_serialization test/test_ros2_to_ros1_serialization.cpp)
     ament_target_dependencies(test_ros2_to_ros1_serialization
+      "geometry_msgs"
+      "rclcpp"
       "ros1_roscpp"
       "ros1_sensor_msgs"
       "ros1_std_msgs"
       "ros1_geometry_msgs"
       "sensor_msgs"
       "std_msgs"
-      "geometry_msgs"
-      "rclcpp"
     )
     target_link_libraries(test_ros2_to_ros1_serialization ${PROJECT_NAME})
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,19 @@ if(BUILD_TESTING)
       "rclcpp"
     )
     target_link_libraries(test_convert_generic ${PROJECT_NAME})
+
+    ament_add_gtest(test_ros2_to_ros1_serialization test/test_ros2_to_ros1_serialization.cpp)
+    ament_target_dependencies(test_ros2_to_ros1_serialization
+      "ros1_roscpp"
+      "ros1_sensor_msgs"
+      "ros1_std_msgs"
+      "ros1_geometry_msgs"
+      "sensor_msgs"
+      "std_msgs"
+      "geometry_msgs"
+      "rclcpp"
+    )
+    target_link_libraries(test_ros2_to_ros1_serialization ${PROJECT_NAME})
   endif()
 
 endif()

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -70,7 +70,7 @@ Factory<
  *   class Factory : public FactoryInterface
  *   {
  *      template<typename STREAM_T, typename ROS2_MSG_T>
- *      static void msg_2_to_1_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+ *      static void convert_all_in_one_stream(STREAM_T & stream, ROS2_MSG_T & msg);
  *   };
  */
 template<>
@@ -79,7 +79,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & msg);
 
@@ -89,7 +89,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & msg);
 
@@ -99,7 +99,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & msg);
 
@@ -127,7 +127,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & msg);
 
@@ -137,7 +137,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & msg);
 
@@ -147,7 +147,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & msg);
 

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -70,7 +70,7 @@ Factory<
  *   class Factory : public FactoryInterface
  *   {
  *      template<typename STREAM_T, typename ROS2_MSG_T>
- *      static void convert_all_in_one_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+ *      static void internal_stream_translate_helper(STREAM_T & stream, ROS2_MSG_T & msg);
  *   };
  */
 template<>
@@ -79,7 +79,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & msg);
 
@@ -89,7 +89,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & msg);
 
@@ -99,7 +99,7 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & msg);
 
@@ -127,7 +127,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & msg);
 
@@ -137,7 +137,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & msg);
 
@@ -147,7 +147,7 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & msg);
 

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -60,20 +60,6 @@ Factory<
   const builtin_interfaces::msg::Duration & ros2_msg,
   std_msgs::Duration & ros1_msg);
 
-/**
- * The first template<> is a specialization for Factory class
- * The second template<> is a specialization for the function argument types
- *
- * For reference:
- *
- *   template<typename ROS1_T, typename ROS2_T>
- *   class Factory : public FactoryInterface
- *   {
- *      template<typename STREAM_T, typename ROS2_MSG_T>
- *      static void internal_stream_translate_helper(STREAM_T & stream, ROS2_MSG_T & msg);
- *   };
- */
-template<>
 template<>
 void
 Factory<
@@ -84,7 +70,6 @@ Factory<
   const builtin_interfaces::msg::Duration & msg);
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Duration,
@@ -93,7 +78,6 @@ Factory<
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & msg);
 
-template<>
 template<>
 void
 Factory<
@@ -122,7 +106,6 @@ Factory<
   std_msgs::Time & ros1_msg);
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Time,
@@ -132,7 +115,6 @@ Factory<
   const builtin_interfaces::msg::Time & msg);
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Time,
@@ -141,7 +123,6 @@ Factory<
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & msg);
 
-template<>
 template<>
 void
 Factory<

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -15,8 +15,11 @@
 #ifndef ROS1_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
 #define ROS1_BRIDGE__BUILTIN_INTERFACES_FACTORIES_HPP_
 
+#include <ros/serialization.h>
+
 // include ROS 1 messages
 #include <std_msgs/Duration.h>
+#include <std_msgs/Header.h>
 #include <std_msgs/Time.h>
 
 #include <memory>
@@ -25,6 +28,7 @@
 // include ROS 2 messages
 #include <builtin_interfaces/msg/duration.hpp>
 #include <builtin_interfaces/msg/time.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include "ros1_bridge/factory.hpp"
 
@@ -57,6 +61,36 @@ Factory<
   std_msgs::Duration & ros1_msg);
 
 template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Duration & msg);
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Duration & msg);
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Duration & msg);
+
+template<>
 void
 Factory<
   std_msgs::Time,
@@ -73,6 +107,36 @@ Factory<
 >::convert_2_to_1(
   const builtin_interfaces::msg::Time & ros2_msg,
   std_msgs::Time & ros1_msg);
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Time & msg);
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Time & msg);
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Time & msg);
 
 }  // namespace ros1_bridge
 

--- a/include/ros1_bridge/builtin_interfaces_factories.hpp
+++ b/include/ros1_bridge/builtin_interfaces_factories.hpp
@@ -60,6 +60,19 @@ Factory<
   const builtin_interfaces::msg::Duration & ros2_msg,
   std_msgs::Duration & ros1_msg);
 
+/**
+ * The first template<> is a specialization for Factory class
+ * The second template<> is a specialization for the function argument types
+ *
+ * For reference:
+ *
+ *   template<typename ROS1_T, typename ROS2_T>
+ *   class Factory : public FactoryInterface
+ *   {
+ *      template<typename STREAM_T, typename ROS2_MSG_T>
+ *      static void msg_2_to_1_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+ *   };
+ */
 template<>
 template<>
 void

--- a/include/ros1_bridge/convert_builtin_interfaces.hpp
+++ b/include/ros1_bridge/convert_builtin_interfaces.hpp
@@ -40,6 +40,19 @@ convert_2_to_1(
   const builtin_interfaces::msg::Duration & ros2_msg,
   ros::Duration & ros1_type);
 
+template<typename STREAM_T>
+void
+msg_2_to_1_stream(
+  STREAM_T & stream,
+  const builtin_interfaces::msg::Duration & msg);
+
+template<typename STREAM_T>
+void
+msg_2_to_1_stream(
+  STREAM_T & stream,
+  builtin_interfaces::msg::Duration & msg);
+
+
 template<>
 void
 convert_1_to_2(
@@ -51,6 +64,18 @@ void
 convert_2_to_1(
   const builtin_interfaces::msg::Time & ros2_msg,
   ros::Time & ros1_type);
+
+template<typename STREAM_T>
+void
+msg_2_to_1_stream(
+  STREAM_T & stream,
+  const builtin_interfaces::msg::Time & msg);
+
+template<typename STREAM_T>
+void
+msg_2_to_1_stream(
+  STREAM_T & stream,
+  builtin_interfaces::msg::Time & msg);
 
 }  // namespace ros1_bridge
 

--- a/include/ros1_bridge/convert_builtin_interfaces.hpp
+++ b/include/ros1_bridge/convert_builtin_interfaces.hpp
@@ -42,13 +42,13 @@ convert_2_to_1(
 
 template<typename STREAM_T>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   STREAM_T & stream,
   const builtin_interfaces::msg::Duration & msg);
 
 template<typename STREAM_T>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   STREAM_T & stream,
   builtin_interfaces::msg::Duration & msg);
 
@@ -67,13 +67,13 @@ convert_2_to_1(
 
 template<typename STREAM_T>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   STREAM_T & stream,
   const builtin_interfaces::msg::Time & msg);
 
 template<typename STREAM_T>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   STREAM_T & stream,
   builtin_interfaces::msg::Time & msg);
 

--- a/include/ros1_bridge/convert_builtin_interfaces.hpp
+++ b/include/ros1_bridge/convert_builtin_interfaces.hpp
@@ -42,13 +42,13 @@ convert_2_to_1(
 
 template<typename STREAM_T>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   STREAM_T & stream,
   const builtin_interfaces::msg::Duration & msg);
 
 template<typename STREAM_T>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   STREAM_T & stream,
   builtin_interfaces::msg::Duration & msg);
 
@@ -67,13 +67,13 @@ convert_2_to_1(
 
 template<typename STREAM_T>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   STREAM_T & stream,
   const builtin_interfaces::msg::Time & msg);
 
 template<typename STREAM_T>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   STREAM_T & stream,
   builtin_interfaces::msg::Time & msg);
 

--- a/include/ros1_bridge/convert_decl.hpp
+++ b/include/ros1_bridge/convert_decl.hpp
@@ -32,7 +32,7 @@ convert_2_to_1(
 
 template<typename ROS2_T, typename STREAM_T>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   STREAM_T & out_stream,
   const ROS2_T & msg);
 

--- a/include/ros1_bridge/convert_decl.hpp
+++ b/include/ros1_bridge/convert_decl.hpp
@@ -30,6 +30,12 @@ convert_2_to_1(
   const ROS2_T & ros2_msg,
   ROS1_T & ros1_msg);
 
+template<typename ROS2_T, typename STREAM_T>
+void
+msg_2_to_1_stream(
+  STREAM_T & out_stream,
+  const ROS2_T & msg);
+
 }  // namespace ros1_bridge
 
 #endif  // ROS1_BRIDGE__CONVERT_DECL_HPP_

--- a/include/ros1_bridge/convert_decl.hpp
+++ b/include/ros1_bridge/convert_decl.hpp
@@ -32,7 +32,7 @@ convert_2_to_1(
 
 template<typename ROS2_T, typename STREAM_T>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   STREAM_T & out_stream,
   const ROS2_T & msg);
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -373,9 +373,15 @@ public:
    * This function is not meant to be used externally. However, since this the internal helper
    * functions call each other for sub messages they must be public.
    */
-  static void internal_stream_translate_helper(ros::serialization::OStream & stream, const ROS2_T & msg);
-  static void internal_stream_translate_helper(ros::serialization::IStream & stream, ROS2_T & msg);
-  static void internal_stream_translate_helper(ros::serialization::LStream & stream, const ROS2_T & msg);
+  static void internal_stream_translate_helper(
+    ros::serialization::OStream & stream,
+    const ROS2_T & msg);
+  static void internal_stream_translate_helper(
+    ros::serialization::IStream & stream,
+    ROS2_T & msg);
+  static void internal_stream_translate_helper(
+    ros::serialization::LStream & stream,
+    const ROS2_T & msg);
 
   std::string ros1_type_name_;
   std::string ros2_type_name_;

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -368,10 +368,13 @@ public:
   static uint32_t length_2_as_1_stream(const ROS2_T & msg);
 
   /**
-   * @brief All-in-one conversion for ROS2 message types to/from ROS1 streams
+   * @brief Internal helper function conversion for ROS2 message types to/from ROS1 streams
+   *
+   * This function is not meant to be used externally. However, since this the internal helper
+   * functions call each other for sub messages they must be public.
    */
   template<typename STREAM_T, typename ROS2_MSG_T>
-  static void convert_all_in_one_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+  static void internal_stream_translate_helper(STREAM_T & stream, ROS2_MSG_T & msg);
 
   std::string ros1_type_name_;
   std::string ros2_type_name_;

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -368,13 +368,14 @@ public:
   static uint32_t length_2_as_1_stream(const ROS2_T & msg);
 
   /**
-   * @brief Internal helper function conversion for ROS2 message types to/from ROS1 streams
+   * @brief Internal helper functions conversion for ROS2 message types to/from ROS1 streams
    *
    * This function is not meant to be used externally. However, since this the internal helper
    * functions call each other for sub messages they must be public.
    */
-  template<typename STREAM_T, typename ROS2_MSG_T>
-  static void internal_stream_translate_helper(STREAM_T & stream, ROS2_MSG_T & msg);
+  static void internal_stream_translate_helper(ros::serialization::OStream & stream, const ROS2_T & msg);
+  static void internal_stream_translate_helper(ros::serialization::IStream & stream, ROS2_T & msg);
+  static void internal_stream_translate_helper(ros::serialization::LStream & stream, const ROS2_T & msg);
 
   std::string ros1_type_name_;
   std::string ros2_type_name_;
@@ -382,6 +383,7 @@ public:
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
   const rosidl_message_type_support_t * type_support_ = nullptr;
 };
+
 
 template<class ROS1_T, class ROS2_T>
 class ServiceFactory : public ServiceFactoryInterface

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -355,20 +355,23 @@ public:
   /**
    * @brief Writes (serializes) a ROS2 class directly to a ROS1 stream
    */
-  static void write_2_to_1_stream(ros::serialization::OStream & out_stream, const ROS2_T & msg);
+  static void convert_2_to_1(const ROS2_T & msg, ros::serialization::OStream & out_stream);
 
   /**
    * @brief Reads (deserializes) a ROS2 class directly from a ROS1 stream
    */
-  static void read_2_to_1_stream(ros::serialization::IStream & in_stream, ROS2_T & msg);
+  static void convert_1_to_2(ros::serialization::IStream & in_stream, ROS2_T & msg);
 
   /**
    * @brief Determines the length of a ROS2 class if it was serialized to a ROS1 stream
    */
-  static uint32_t length_2_to_1_stream(const ROS2_T & msg);
+  static uint32_t length_2_as_1_stream(const ROS2_T & msg);
 
+  /**
+   * @brief All-in-one conversion for ROS2 message types to/from ROS1 streams
+   */
   template<typename STREAM_T, typename ROS2_MSG_T>
-  static void msg_2_to_1_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+  static void convert_all_in_one_stream(STREAM_T & stream, ROS2_MSG_T & msg);
 
   std::string ros1_type_name_;
   std::string ros2_type_name_;

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -352,6 +352,24 @@ public:
     return true;
   }
 
+  /**
+   * @brief Writes (serializes) a ROS2 class directly to a ROS1 stream
+   */
+  static void write_2_to_1_stream(ros::serialization::OStream & out_stream, const ROS2_T & msg);
+
+  /**
+   * @brief Reads (deserializes) a ROS2 class directly from a ROS1 stream
+   */
+  static void read_2_to_1_stream(ros::serialization::IStream & in_stream, ROS2_T & msg);
+
+  /**
+   * @brief Determines the length of a ROS2 class if it was serialized to a ROS1 stream
+   */
+  static uint32_t length_2_to_1_stream(const ROS2_T & msg);
+
+  template<typename STREAM_T, typename ROS2_MSG_T>
+  static void msg_2_to_1_stream(STREAM_T & stream, ROS2_MSG_T & msg);
+
   std::string ros1_type_name_;
   std::string ros2_type_name_;
 

--- a/package.xml
+++ b/package.xml
@@ -47,10 +47,12 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>demo_nodes_cpp</test_depend>
   <test_depend>diagnostic_msgs</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
+  <test_depend>sensor_msgs</test_depend>
   <test_depend>ros2run</test_depend>
 
   <group_depend>rosidl_interface_packages</group_depend>

--- a/package.xml
+++ b/package.xml
@@ -52,8 +52,8 @@
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
-  <test_depend>sensor_msgs</test_depend>
   <test_depend>ros2run</test_depend>
+  <test_depend>sensor_msgs</test_depend>
 
   <group_depend>rosidl_interface_packages</group_depend>
 

--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -394,14 +394,15 @@ static void streamPrimitiveVector(ros::serialization::IStream & stream, VEC_PRIM
 // builtin_interfaces_factories.
 @[  else]
 
+@[    for stream_type, msg_const in (("OStream", "const"), ("IStream", ""), ("LStream", "const")) ]@
 template<>
-template<typename STREAM_T, typename ROS2_MSG_T>
 void
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::internal_stream_translate_helper(STREAM_T& stream,
-                     ROS2_MSG_T& ros2_msg)
+>::internal_stream_translate_helper(
+  ros::serialization::@(stream_type) & stream,
+  @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name) @(msg_const) & ros2_msg)
 {
 @[    if m.ros1_field_missing_in_ros2]@
   // Only messages that have exactly matching fields are supported -- for now
@@ -494,6 +495,9 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
 @[      end for]@
 @[    end if]@
 }
+
+
+@[    end for]@
 
 template<>
 void

--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -389,7 +389,7 @@ static void streamPrimitiveVector(ros::serialization::IStream & stream, VEC_PRIM
 
 @[  if m.ros2_msg.package_name=="std_msgs" and m.ros2_msg.message_name=="Header"]
 // std_msgs/Header does not have a 1-to-1 field mapping because it ROS2 dropped the "seq" field.
-// Typically, the auto-generated convert_all_in_one_stream() function will throw an exception for this.
+// Typically, the auto-generated internal_stream_translate_helper() function will throw an exception for this.
 // However, since Header is so fundimental, a hand-written template specialization is provided in
 // builtin_interfaces_factories.
 @[  else]
@@ -400,7 +400,7 @@ void
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::convert_all_in_one_stream(STREAM_T& stream,
+>::internal_stream_translate_helper(STREAM_T& stream,
                      ROS2_MSG_T& ros2_msg)
 {
 @[    if m.ros1_field_missing_in_ros2]@
@@ -424,13 +424,13 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
   stream.next(ros2_msg.@(ros2_field_selection));
 @[        elif ros2_fields[-1].type.namespaces[0] == 'builtin_interfaces']@
   // write builtin field
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg.@(ros2_field_selection));
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg.@(ros2_field_selection));
 @[          else]@
   // write sub message field
   Factory<
     @(ros1_fields[-1].pkg_name)::@(ros1_fields[-1].msg_name),
     @(ros2_fields[-1].type.namespaces[0])::msg::@(ros2_fields[-1].type.name)
-  >::convert_all_in_one_stream(stream, ros2_msg.@(ros2_field_selection));
+  >::internal_stream_translate_helper(stream, ros2_msg.@(ros2_field_selection));
 @[          end if]@
 @[        else]@
   // write array or sequence field
@@ -463,7 +463,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
     ++ros2_it
   )
   {
-    ros1_bridge::convert_all_in_one_stream(stream, *ros2_it);
+    ros1_bridge::internal_stream_translate_helper(stream, *ros2_it);
   }
 @[            else]@
   // write primitive type
@@ -480,12 +480,12 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
     {
       // write sub message element
 @[          if ros2_fields[-1].type.value_type.namespaces[0] == 'builtin_interfaces']@
-      ros1_bridge::convert_all_in_one_stream(stream, *ros2_it);
+      ros1_bridge::internal_stream_translate_helper(stream, *ros2_it);
 @[            else]@
       Factory<
         @(ros1_fields[-1].pkg_name)::@(ros1_fields[-1].msg_name),
         @(ros2_fields[-1].type.value_type.namespaces[0])::msg::@(ros2_fields[-1].type.value_type.name)
-      >::convert_all_in_one_stream(stream, *ros2_it);
+      >::internal_stream_translate_helper(stream, *ros2_it);
 @[            end if]@
     }
   }
@@ -503,7 +503,7 @@ Factory<
 >::convert_2_to_1(const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg,
                   ros::serialization::OStream& out_stream)
 {
-  convert_all_in_one_stream(out_stream, ros2_msg);
+  internal_stream_translate_helper(out_stream, ros2_msg);
 }
 
 
@@ -515,7 +515,7 @@ Factory<
 >::convert_1_to_2(ros::serialization::IStream& in_stream,
                   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
 {
-  convert_all_in_one_stream(in_stream, ros2_msg);
+  internal_stream_translate_helper(in_stream, ros2_msg);
 }
 
 template<>
@@ -526,7 +526,7 @@ Factory<
 >::length_2_as_1_stream(const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  convert_all_in_one_stream(len_stream, ros2_msg);
+  internal_stream_translate_helper(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 

--- a/resource/interface_factories.cpp.em
+++ b/resource/interface_factories.cpp.em
@@ -389,7 +389,7 @@ static void streamPrimitiveVector(ros::serialization::IStream & stream, VEC_PRIM
 
 @[  if m.ros2_msg.package_name=="std_msgs" and m.ros2_msg.message_name=="Header"]
 // std_msgs/Header does not have a 1-to-1 field mapping because it ROS2 dropped the "seq" field.
-// Typically, the auto-generated msg_2_to_1_stream() function will throw an exception for this.
+// Typically, the auto-generated convert_all_in_one_stream() function will throw an exception for this.
 // However, since Header is so fundimental, a hand-written template specialization is provided in
 // builtin_interfaces_factories.
 @[  else]
@@ -400,7 +400,7 @@ void
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::msg_2_to_1_stream(STREAM_T& stream,
+>::convert_all_in_one_stream(STREAM_T& stream,
                      ROS2_MSG_T& ros2_msg)
 {
 @[    if m.ros1_field_missing_in_ros2]@
@@ -424,13 +424,13 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
   stream.next(ros2_msg.@(ros2_field_selection));
 @[        elif ros2_fields[-1].type.namespaces[0] == 'builtin_interfaces']@
   // write builtin field
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg.@(ros2_field_selection));
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg.@(ros2_field_selection));
 @[          else]@
   // write sub message field
   Factory<
     @(ros1_fields[-1].pkg_name)::@(ros1_fields[-1].msg_name),
     @(ros2_fields[-1].type.namespaces[0])::msg::@(ros2_fields[-1].type.name)
-  >::msg_2_to_1_stream(stream, ros2_msg.@(ros2_field_selection));
+  >::convert_all_in_one_stream(stream, ros2_msg.@(ros2_field_selection));
 @[          end if]@
 @[        else]@
   // write array or sequence field
@@ -463,7 +463,7 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
     ++ros2_it
   )
   {
-    ros1_bridge::msg_2_to_1_stream(stream, *ros2_it);
+    ros1_bridge::convert_all_in_one_stream(stream, *ros2_it);
   }
 @[            else]@
   // write primitive type
@@ -480,12 +480,12 @@ if isinstance(ros2_fields[-1].type, NamespacedType):
     {
       // write sub message element
 @[          if ros2_fields[-1].type.value_type.namespaces[0] == 'builtin_interfaces']@
-      ros1_bridge::msg_2_to_1_stream(stream, *ros2_it);
+      ros1_bridge::convert_all_in_one_stream(stream, *ros2_it);
 @[            else]@
       Factory<
         @(ros1_fields[-1].pkg_name)::@(ros1_fields[-1].msg_name),
         @(ros2_fields[-1].type.value_type.namespaces[0])::msg::@(ros2_fields[-1].type.value_type.name)
-      >::msg_2_to_1_stream(stream, *ros2_it);
+      >::convert_all_in_one_stream(stream, *ros2_it);
 @[            end if]@
     }
   }
@@ -500,10 +500,10 @@ void
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::write_2_to_1_stream(ros::serialization::OStream& out_stream,
-                       const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
+>::convert_2_to_1(const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg,
+                  ros::serialization::OStream& out_stream)
 {
-  msg_2_to_1_stream(out_stream, ros2_msg);
+  convert_all_in_one_stream(out_stream, ros2_msg);
 }
 
 
@@ -512,10 +512,10 @@ void
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::read_2_to_1_stream(ros::serialization::IStream& in_stream,
-                      @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
+>::convert_1_to_2(ros::serialization::IStream& in_stream,
+                  @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
 {
-  msg_2_to_1_stream(in_stream, ros2_msg);
+  convert_all_in_one_stream(in_stream, ros2_msg);
 }
 
 template<>
@@ -523,10 +523,10 @@ uint32_t
 Factory<
   @(m.ros1_msg.package_name)::@(m.ros1_msg.message_name),
   @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)
->::length_2_to_1_stream(const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
+>::length_2_as_1_stream(const @(m.ros2_msg.package_name)::msg::@(m.ros2_msg.message_name)& ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  msg_2_to_1_stream(len_stream, ros2_msg);
+  convert_all_in_one_stream(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -808,7 +808,7 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
     ros1_field_missing_in_ros2 = any(ros1_fields_not_mapped)
 
     mapping.ros1_field_missing_in_ros2 = ros1_field_missing_in_ros2
-            
+
     if ros1_field_missing_in_ros2:
         # if some fields exist in ROS 1 but not in ROS 2
         # check that no fields exist in ROS 2 but not in ROS 1

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -807,6 +807,8 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
 
     ros1_field_missing_in_ros2 = any(ros1_fields_not_mapped)
 
+    mapping.ros1_field_missing_in_ros2 = ros1_field_missing_in_ros2
+            
     if ros1_field_missing_in_ros2:
         # if some fields exist in ROS 1 but not in ROS 2
         # check that no fields exist in ROS 2 but not in ROS 1
@@ -912,7 +914,8 @@ class Mapping:
         'ros2_msg',
         'fields_1_to_2',
         'fields_2_to_1',
-        'depends_on_ros2_messages'
+        'depends_on_ros2_messages',
+        'ros1_field_missing_in_ros2',
     ]
 
     def __init__(self, ros1_msg, ros2_msg):
@@ -921,6 +924,7 @@ class Mapping:
         self.fields_1_to_2 = OrderedDict()
         self.fields_2_to_1 = OrderedDict()
         self.depends_on_ros2_messages = set()
+        self.ros1_field_missing_in_ros2 = False
 
     def add_field_pair(self, ros1_fields, ros2_members):
         """

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -86,11 +86,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -99,11 +99,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -112,11 +112,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -128,7 +128,7 @@ Factory<
   const builtin_interfaces::msg::Duration & ros2_msg,
   ros::serialization::OStream & out_stream)
 {
-  convert_all_in_one_stream(out_stream, ros2_msg);
+  internal_stream_translate_helper(out_stream, ros2_msg);
 }
 
 template<>
@@ -140,7 +140,7 @@ Factory<
   ros::serialization::IStream & in_stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
-  convert_all_in_one_stream(in_stream, ros2_msg);
+  internal_stream_translate_helper(in_stream, ros2_msg);
 }
 
 template<>
@@ -151,7 +151,7 @@ Factory<
 >::length_2_as_1_stream(const builtin_interfaces::msg::Duration & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  convert_all_in_one_stream(len_stream, ros2_msg);
+  internal_stream_translate_helper(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 
@@ -185,11 +185,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -198,11 +198,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -211,11 +211,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
 template<>
@@ -227,7 +227,7 @@ Factory<
   const builtin_interfaces::msg::Time & ros2_msg,
   ros::serialization::OStream & out_stream)
 {
-  convert_all_in_one_stream(out_stream, ros2_msg);
+  internal_stream_translate_helper(out_stream, ros2_msg);
 }
 
 template<>
@@ -239,7 +239,7 @@ Factory<
   ros::serialization::IStream & in_stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
-  convert_all_in_one_stream(in_stream, ros2_msg);
+  internal_stream_translate_helper(in_stream, ros2_msg);
 }
 
 template<>
@@ -250,7 +250,7 @@ Factory<
 >::length_2_as_1_stream(const builtin_interfaces::msg::Time & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  convert_all_in_one_stream(len_stream, ros2_msg);
+  internal_stream_translate_helper(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 
@@ -260,7 +260,7 @@ void
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
->::convert_all_in_one_stream(
+>::internal_stream_translate_helper(
   STREAM_T & stream,
   ROS2_MSG_T & ros2_msg)
 {
@@ -270,7 +270,7 @@ Factory<
 
   // write non-array field
   // write builtin field
-  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg.stamp);
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg.stamp);
 
   // write non-array field
   // write primitive field
@@ -286,7 +286,7 @@ Factory<
   const std_msgs::msg::Header & ros2_msg,
   ros::serialization::OStream & out_stream)
 {
-  convert_all_in_one_stream(out_stream, ros2_msg);
+  internal_stream_translate_helper(out_stream, ros2_msg);
 }
 
 
@@ -299,7 +299,7 @@ Factory<
   ros::serialization::IStream & in_stream,
   std_msgs::msg::Header & ros2_msg)
 {
-  convert_all_in_one_stream(in_stream, ros2_msg);
+  internal_stream_translate_helper(in_stream, ros2_msg);
 }
 
 template<>
@@ -310,7 +310,7 @@ Factory<
 >::length_2_as_1_stream(const std_msgs::msg::Header & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  convert_all_in_one_stream(len_stream, ros2_msg);
+  internal_stream_translate_helper(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -86,11 +86,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -99,11 +99,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -112,11 +112,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -124,11 +124,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::write_2_to_1_stream(
-  ros::serialization::OStream & out_stream,
-  const builtin_interfaces::msg::Duration & ros2_msg)
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Duration & ros2_msg,
+  ros::serialization::OStream & out_stream)
 {
-  msg_2_to_1_stream(out_stream, ros2_msg);
+  convert_all_in_one_stream(out_stream, ros2_msg);
 }
 
 template<>
@@ -136,11 +136,11 @@ void
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::read_2_to_1_stream(
+>::convert_1_to_2(
   ros::serialization::IStream & in_stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
-  msg_2_to_1_stream(in_stream, ros2_msg);
+  convert_all_in_one_stream(in_stream, ros2_msg);
 }
 
 template<>
@@ -148,10 +148,10 @@ uint32_t
 Factory<
   std_msgs::Duration,
   builtin_interfaces::msg::Duration
->::length_2_to_1_stream(const builtin_interfaces::msg::Duration & ros2_msg)
+>::length_2_as_1_stream(const builtin_interfaces::msg::Duration & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  msg_2_to_1_stream(len_stream, ros2_msg);
+  convert_all_in_one_stream(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 
@@ -185,11 +185,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -198,11 +198,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -211,11 +211,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg);
 }
 
 template<>
@@ -223,11 +223,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::write_2_to_1_stream(
-  ros::serialization::OStream & out_stream,
-  const builtin_interfaces::msg::Time & ros2_msg)
+>::convert_2_to_1(
+  const builtin_interfaces::msg::Time & ros2_msg,
+  ros::serialization::OStream & out_stream)
 {
-  msg_2_to_1_stream(out_stream, ros2_msg);
+  convert_all_in_one_stream(out_stream, ros2_msg);
 }
 
 template<>
@@ -235,11 +235,11 @@ void
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::read_2_to_1_stream(
+>::convert_1_to_2(
   ros::serialization::IStream & in_stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
-  msg_2_to_1_stream(in_stream, ros2_msg);
+  convert_all_in_one_stream(in_stream, ros2_msg);
 }
 
 template<>
@@ -247,10 +247,10 @@ uint32_t
 Factory<
   std_msgs::Time,
   builtin_interfaces::msg::Time
->::length_2_to_1_stream(const builtin_interfaces::msg::Time & ros2_msg)
+>::length_2_as_1_stream(const builtin_interfaces::msg::Time & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  msg_2_to_1_stream(len_stream, ros2_msg);
+  convert_all_in_one_stream(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 
@@ -260,7 +260,7 @@ void
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
->::msg_2_to_1_stream(
+>::convert_all_in_one_stream(
   STREAM_T & stream,
   ROS2_MSG_T & ros2_msg)
 {
@@ -270,7 +270,7 @@ Factory<
 
   // write non-array field
   // write builtin field
-  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg.stamp);
+  ros1_bridge::convert_all_in_one_stream(stream, ros2_msg.stamp);
 
   // write non-array field
   // write primitive field
@@ -282,11 +282,11 @@ void
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
->::write_2_to_1_stream(
-  ros::serialization::OStream & out_stream,
-  const std_msgs::msg::Header & ros2_msg)
+>::convert_2_to_1(
+  const std_msgs::msg::Header & ros2_msg,
+  ros::serialization::OStream & out_stream)
 {
-  msg_2_to_1_stream(out_stream, ros2_msg);
+  convert_all_in_one_stream(out_stream, ros2_msg);
 }
 
 
@@ -295,11 +295,11 @@ void
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
->::read_2_to_1_stream(
+>::convert_1_to_2(
   ros::serialization::IStream & in_stream,
   std_msgs::msg::Header & ros2_msg)
 {
-  msg_2_to_1_stream(in_stream, ros2_msg);
+  convert_all_in_one_stream(in_stream, ros2_msg);
 }
 
 template<>
@@ -307,10 +307,10 @@ uint32_t
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
->::length_2_to_1_stream(const std_msgs::msg::Header & ros2_msg)
+>::length_2_as_1_stream(const std_msgs::msg::Header & ros2_msg)
 {
   ros::serialization::LStream len_stream;
-  msg_2_to_1_stream(len_stream, ros2_msg);
+  convert_all_in_one_stream(len_stream, ros2_msg);
   return len_stream.getLength();
 }
 

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -81,6 +81,81 @@ Factory<
 }
 
 template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Duration & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::write_2_to_1_stream(
+  ros::serialization::OStream & out_stream,
+  const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  msg_2_to_1_stream(out_stream, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::read_2_to_1_stream(
+  ros::serialization::IStream & in_stream,
+  builtin_interfaces::msg::Duration & ros2_msg)
+{
+  msg_2_to_1_stream(in_stream, ros2_msg);
+}
+
+template<>
+uint32_t
+Factory<
+  std_msgs::Duration,
+  builtin_interfaces::msg::Duration
+>::length_2_to_1_stream(const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  ros::serialization::LStream len_stream;
+  msg_2_to_1_stream(len_stream, ros2_msg);
+  return len_stream.getLength();
+}
+
+template<>
 void
 Factory<
   std_msgs::Time,
@@ -102,6 +177,141 @@ Factory<
   std_msgs::Time & ros1_msg)
 {
   ros1_bridge::convert_2_to_1(ros2_msg, ros1_msg.data);
+}
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Time & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Time & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Time & ros2_msg)
+{
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::write_2_to_1_stream(
+  ros::serialization::OStream & out_stream,
+  const builtin_interfaces::msg::Time & ros2_msg)
+{
+  msg_2_to_1_stream(out_stream, ros2_msg);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::read_2_to_1_stream(
+  ros::serialization::IStream & in_stream,
+  builtin_interfaces::msg::Time & ros2_msg)
+{
+  msg_2_to_1_stream(in_stream, ros2_msg);
+}
+
+template<>
+uint32_t
+Factory<
+  std_msgs::Time,
+  builtin_interfaces::msg::Time
+>::length_2_to_1_stream(const builtin_interfaces::msg::Time & ros2_msg)
+{
+  ros::serialization::LStream len_stream;
+  msg_2_to_1_stream(len_stream, ros2_msg);
+  return len_stream.getLength();
+}
+
+template<>
+template<typename STREAM_T, typename ROS2_MSG_T>
+void
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::msg_2_to_1_stream(
+  STREAM_T & stream,
+  ROS2_MSG_T & ros2_msg)
+{
+  // ROS2 Header is missing seq, provide a fake one so stream matches
+  uint32_t seq = 0;
+  stream.next(seq);
+
+  // write non-array field
+  // write builtin field
+  ros1_bridge::msg_2_to_1_stream(stream, ros2_msg.stamp);
+
+  // write non-array field
+  // write primitive field
+  stream.next(ros2_msg.frame_id);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::write_2_to_1_stream(
+  ros::serialization::OStream & out_stream,
+  const std_msgs::msg::Header & ros2_msg)
+{
+  msg_2_to_1_stream(out_stream, ros2_msg);
+}
+
+
+template<>
+void
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::read_2_to_1_stream(
+  ros::serialization::IStream & in_stream,
+  std_msgs::msg::Header & ros2_msg)
+{
+  msg_2_to_1_stream(in_stream, ros2_msg);
+}
+
+template<>
+uint32_t
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::length_2_to_1_stream(const std_msgs::msg::Header & ros2_msg)
+{
+  ros::serialization::LStream len_stream;
+  msg_2_to_1_stream(len_stream, ros2_msg);
+  return len_stream.getLength();
 }
 
 }  // namespace ros1_bridge

--- a/src/builtin_interfaces_factories.cpp
+++ b/src/builtin_interfaces_factories.cpp
@@ -81,7 +81,6 @@ Factory<
 }
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Duration,
@@ -94,7 +93,6 @@ Factory<
 }
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Duration,
@@ -106,7 +104,6 @@ Factory<
   ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
-template<>
 template<>
 void
 Factory<
@@ -180,7 +177,6 @@ Factory<
 }
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Time,
@@ -193,7 +189,6 @@ Factory<
 }
 
 template<>
-template<>
 void
 Factory<
   std_msgs::Time,
@@ -205,7 +200,6 @@ Factory<
   ros1_bridge::internal_stream_translate_helper(stream, ros2_msg);
 }
 
-template<>
 template<>
 void
 Factory<
@@ -255,14 +249,57 @@ Factory<
 }
 
 template<>
-template<typename STREAM_T, typename ROS2_MSG_T>
 void
 Factory<
   std_msgs::Header,
   std_msgs::msg::Header
 >::internal_stream_translate_helper(
-  STREAM_T & stream,
-  ROS2_MSG_T & ros2_msg)
+  ros::serialization::OStream & stream,
+  const std_msgs::msg::Header & ros2_msg)
+{
+  // ROS2 Header is missing seq, provide a fake one so stream matches
+  uint32_t seq = 0;
+  stream.next(seq);
+
+  // write non-array field
+  // write builtin field
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg.stamp);
+
+  // write non-array field
+  // write primitive field
+  stream.next(ros2_msg.frame_id);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::internal_stream_translate_helper(
+  ros::serialization::IStream & stream,
+  std_msgs::msg::Header & ros2_msg)
+{
+  // ROS2 Header is missing seq, provide a fake one so stream matches
+  uint32_t seq = 0;
+  stream.next(seq);
+
+  // write non-array field
+  // write builtin field
+  ros1_bridge::internal_stream_translate_helper(stream, ros2_msg.stamp);
+
+  // write non-array field
+  // write primitive field
+  stream.next(ros2_msg.frame_id);
+}
+
+template<>
+void
+Factory<
+  std_msgs::Header,
+  std_msgs::msg::Header
+>::internal_stream_translate_helper(
+  ros::serialization::LStream & stream,
+  const std_msgs::msg::Header & ros2_msg)
 {
   // ROS2 Header is missing seq, provide a fake one so stream matches
   uint32_t seq = 0;

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -14,6 +14,8 @@
 
 #include "ros1_bridge/convert_builtin_interfaces.hpp"
 
+#include "ros/serialization.h"
+
 namespace ros1_bridge
 {
 
@@ -37,6 +39,35 @@ convert_2_to_1(
   ros1_type.nsec = ros2_msg.nanosec;
 }
 
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
+}
+
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Duration & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
+}
+
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Duration & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
+}
 
 template<>
 void
@@ -56,6 +87,36 @@ convert_2_to_1(
 {
   ros1_type.sec = ros2_msg.sec;
   ros1_type.nsec = ros2_msg.nanosec;
+}
+
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::OStream & stream,
+  const builtin_interfaces::msg::Time & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
+}
+
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::IStream & stream,
+  builtin_interfaces::msg::Time & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
+}
+
+template<>
+void
+msg_2_to_1_stream(
+  ros::serialization::LStream & stream,
+  const builtin_interfaces::msg::Time & ros2_msg)
+{
+  stream.next(ros2_msg.sec);
+  stream.next(ros2_msg.nanosec);
 }
 
 }  // namespace ros1_bridge

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -41,7 +41,7 @@ convert_2_to_1(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -51,7 +51,7 @@ msg_2_to_1_stream(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -61,7 +61,7 @@ msg_2_to_1_stream(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -91,7 +91,7 @@ convert_2_to_1(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
@@ -101,7 +101,7 @@ msg_2_to_1_stream(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
@@ -111,7 +111,7 @@ msg_2_to_1_stream(
 
 template<>
 void
-msg_2_to_1_stream(
+convert_all_in_one_stream(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {

--- a/src/convert_builtin_interfaces.cpp
+++ b/src/convert_builtin_interfaces.cpp
@@ -41,7 +41,7 @@ convert_2_to_1(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -51,7 +51,7 @@ convert_all_in_one_stream(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -61,7 +61,7 @@ convert_all_in_one_stream(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Duration & ros2_msg)
 {
@@ -91,7 +91,7 @@ convert_2_to_1(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::OStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {
@@ -101,7 +101,7 @@ convert_all_in_one_stream(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::IStream & stream,
   builtin_interfaces::msg::Time & ros2_msg)
 {
@@ -111,7 +111,7 @@ convert_all_in_one_stream(
 
 template<>
 void
-convert_all_in_one_stream(
+internal_stream_translate_helper(
   ros::serialization::LStream & stream,
   const builtin_interfaces::msg::Time & ros2_msg)
 {

--- a/test/test_ros2_to_ros1_serialization.cpp
+++ b/test/test_ros2_to_ros1_serialization.cpp
@@ -1,0 +1,460 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GTest
+#include <gtest/gtest.h>
+
+// ROS1 Messsages
+#include <geometry_msgs/PoseArray.h>
+#include <geometry_msgs/Vector3.h>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/Imu.h>
+#include <std_msgs/Duration.h>
+#include <std_msgs/Header.h>
+#include <std_msgs/String.h>
+#include <std_msgs/Time.h>
+
+// C++ Standard Library
+#include <string>
+#include <type_traits>
+#include <tuple>
+
+// ros1_bridge
+#include "ros1_bridge/bridge.hpp"
+#include "ros1_bridge/factory.hpp"
+
+// RCLCPP
+#include "rclcpp/serialized_message.hpp"
+
+// ROS2 Messsages
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <std_msgs/msg/header.hpp>
+#include <std_msgs/msg/string.hpp>
+
+
+template<typename ROS1_T_, typename ROS2_T_>
+struct GenericTestBase
+{
+  using ROS1_T = ROS1_T_;
+  using ROS2_T = ROS2_T_;
+  using FACTORY_T = ros1_bridge::Factory<ROS1_T, ROS2_T>;
+
+  FACTORY_T factory;
+  ROS1_T ros1_msg;
+  ROS2_T ros2_msg;
+  GenericTestBase(const std::string & ros1_type_name, const std::string & ros2_type_name)
+  : factory(ros1_type_name, ros2_type_name) {}
+
+  // Generate serialized buffer from ROS1 message
+  static std::vector<uint8_t> generateRos1SerializedMessage(const ROS1_T & ros1_msg)
+  {
+    // Serialize ROS1 message
+    const uint32_t length = ros::serialization::serializationLength(ros1_msg);
+    std::vector<uint8_t> buffer(length);
+    ros::serialization::OStream out_stream(buffer.data(), length);
+    ros::serialization::serialize(out_stream, ros1_msg);
+    return buffer;
+  }
+
+  // Generate SerializedMessage from a ROS2 message
+  rclcpp::SerializedMessage generateRos2SerializedMessage(const ROS2_T & ros2_msg)
+  {
+    // Directly serialize ROS2 message
+    rclcpp::SerializedMessage serialized_msg;
+    auto ret = rmw_serialize(
+      &ros2_msg, factory.type_support_,
+      &serialized_msg.get_rcl_serialized_message());
+    EXPECT_EQ(RMW_RET_OK, ret);
+    return serialized_msg;
+  }
+
+  static bool compare(const ROS2_T &, const ROS2_T &)
+  {
+    return false;
+  }
+};
+
+template<typename T>
+bool compareXYZ(const T & a, const T & b)
+{
+  return (a.x == b.x) && (a.y == b.y) && (a.z == b.z);
+}
+
+template<typename T>
+bool compareXYZW(const T & a, const T & b)
+{
+  return (a.x == b.x) && (a.y == b.y) && (a.z == b.z) && (a.w == b.w);
+}
+
+bool compareTime(
+  const builtin_interfaces::msg::Time & a,
+  const builtin_interfaces::msg::Time & b)
+{
+  return (a.sec == b.sec) && (a.nanosec == b.nanosec);
+}
+
+bool compareDuration(
+  const builtin_interfaces::msg::Duration & a,
+  const builtin_interfaces::msg::Duration & b)
+{
+  return (a.sec == b.sec) && (a.nanosec == b.nanosec);
+}
+
+bool compareHeader(
+  const std_msgs::msg::Header & a,
+  const std_msgs::msg::Header & b)
+{
+  return compareTime(a.stamp, b.stamp) && (a.frame_id == b.frame_id);
+}
+
+bool comparePose(
+  const geometry_msgs::msg::Pose & a,
+  const geometry_msgs::msg::Pose & b)
+{
+  return compareXYZ(a.position, b.position) && compareXYZW(a.orientation, b.orientation);
+}
+
+bool comparePoseArray(
+  const geometry_msgs::msg::PoseArray & a,
+  const geometry_msgs::msg::PoseArray & b)
+{
+  if (!compareHeader(a.header, b.header)) {
+    return false;
+  }
+  if (a.poses.size() != b.poses.size()) {
+    std::cerr << "a.poses.size() != b.poses.size()" << a.poses.size() << " != " << b.poses.size() <<
+      std::endl;
+    return false;
+  }
+  for (size_t idx = 0; idx < a.poses.size(); ++idx) {
+    if (!comparePose(a.poses.at(idx), b.poses.at(idx))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+struct Vector3Test : public GenericTestBase<geometry_msgs::Vector3, geometry_msgs::msg::Vector3>
+{
+  Vector3Test()
+  : GenericTestBase("geometry_msgs/Vector3", "geometry_msgs/msg/Vector3")
+  {
+    ros1_msg.x = ros2_msg.x = 1.1;
+    ros1_msg.y = ros2_msg.y = 2.2;
+    ros1_msg.z = ros2_msg.z = 3.3;
+  }
+
+  static bool compare(
+    const geometry_msgs::msg::Vector3 & a,
+    const geometry_msgs::msg::Vector3 & b)
+  {
+    return compareXYZ(a, b);
+  }
+};
+
+
+struct StringTestEmpty : public GenericTestBase<std_msgs::String,
+    std_msgs::msg::String>
+{
+  StringTestEmpty()
+  : GenericTestBase("std_msgs/String", "std_msgs/msg/String") {}
+
+  static bool compare(
+    const std_msgs::msg::String & a,
+    const std_msgs::msg::String & b)
+  {
+    return a.data == b.data;
+  }
+};
+
+
+struct StringTestHello : public StringTestEmpty
+{
+  StringTestHello()
+  {
+    ros1_msg.data = ros2_msg.data = "hello";
+  }
+};
+
+struct TimeTest : public GenericTestBase<
+    std_msgs::Time,
+    builtin_interfaces::msg::Time>
+{
+  TimeTest()
+  : GenericTestBase("std_msgs/Time", "builtin_interfaces/msg/Time")
+  {
+    ros1_msg.data.sec = ros2_msg.sec = 1000 * 2000;
+    ros1_msg.data.nsec = ros2_msg.nanosec = 1000 * 1000 * 1000;
+  }
+
+  static bool compare(
+    const builtin_interfaces::msg::Time & a,
+    const builtin_interfaces::msg::Time & b)
+  {
+    return compareTime(a, b);
+  }
+};
+
+struct DurationTest : public GenericTestBase<
+    std_msgs::Duration,
+    builtin_interfaces::msg::Duration>
+{
+  DurationTest()
+  : GenericTestBase("std_msgs/Duration", "builtin_interfaces/msg/Duration")
+  {
+    ros1_msg.data.sec = ros2_msg.sec = 1001 * 2001;
+    ros1_msg.data.nsec = ros2_msg.nanosec = 1002 * 1003 * 1004;
+  }
+
+  static bool compare(
+    const builtin_interfaces::msg::Duration & a,
+    const builtin_interfaces::msg::Duration & b)
+  {
+    return compareDuration(a, b);
+  }
+};
+
+struct HeaderTestEmpty : public GenericTestBase<
+    std_msgs::Header,
+    std_msgs::msg::Header>
+{
+  HeaderTestEmpty()
+  : GenericTestBase("std_msgs/Header", "std_msgs/msg/Header")
+  {
+    ros1_msg.stamp.sec = ros2_msg.stamp.sec = 100 * 100;
+    ros1_msg.stamp.nsec = ros2_msg.stamp.nanosec = 100 * 200 * 300;
+    ros1_msg.seq = 0;
+    // Leave header.seq as zero, ros2_msg header does not have seq number so generic
+    // serialization function will always write a zero to output stream
+  }
+
+  static bool compare(
+    const std_msgs::msg::Header & a,
+    const std_msgs::msg::Header & b)
+  {
+    return compareHeader(a, b);
+  }
+};
+
+struct HeaderTestBaseLink : public HeaderTestEmpty
+{
+  HeaderTestBaseLink()
+  {
+    ros1_msg.frame_id = ros2_msg.frame_id = "base_link";
+  }
+
+  static bool compare(
+    const std_msgs::msg::Header & a,
+    const std_msgs::msg::Header & b)
+  {
+    return compareHeader(a, b);
+  }
+};
+
+struct PoseTest : public GenericTestBase<
+    geometry_msgs::Pose,
+    geometry_msgs::msg::Pose>
+{
+  PoseTest()
+  : GenericTestBase("geometry_msgs/Pose", "geometry_msgs/msg/Pose")
+  {
+    ros1_msg.position.x = ros2_msg.position.x = 1.0;
+    ros1_msg.position.y = ros2_msg.position.y = 2.0;
+    ros1_msg.position.z = ros2_msg.position.z = 3.0;
+    ros1_msg.orientation.x = ros2_msg.orientation.x = 4.0;
+    ros1_msg.orientation.y = ros2_msg.orientation.y = 5.0;
+    ros1_msg.orientation.z = ros2_msg.orientation.z = 6.0;
+    ros1_msg.orientation.w = ros2_msg.orientation.w = 7.0;
+  }
+
+  static bool compare(
+    const geometry_msgs::msg::Pose & a,
+    const geometry_msgs::msg::Pose & b)
+  {
+    return comparePose(a, b);
+  }
+};
+
+struct PoseArrayTestEmpty : public GenericTestBase<
+    geometry_msgs::PoseArray,
+    geometry_msgs::msg::PoseArray>
+{
+  PoseArrayTestEmpty()
+  : GenericTestBase("geometry_msgs/PoseArray", "geometry_msgs/msg/PoseArray") {}
+
+  static bool compare(
+    const geometry_msgs::msg::PoseArray & a,
+    const geometry_msgs::msg::PoseArray & b)
+  {
+    return comparePoseArray(a, b);
+  }
+};
+
+struct PoseArrayTest : public PoseArrayTestEmpty
+{
+  PoseArrayTest()
+  {
+    ros1_msg.header.frame_id = ros2_msg.header.frame_id = "base_link";
+    ros1_msg.header.stamp.sec = ros2_msg.header.stamp.sec = 0x12345678;
+    ros1_msg.header.stamp.nsec = ros2_msg.header.stamp.nanosec = 0x76543210;
+    const size_t size = 10;
+    ros1_msg.poses.resize(size);
+    ros2_msg.poses.resize(size);
+    for (size_t ii = 0; ii < size; ++ii) {
+      auto & pose1 = ros1_msg.poses.at(ii);
+      auto & pose2 = ros2_msg.poses.at(ii);
+      pose1.orientation.x = pose2.orientation.x = 0.1 * ii;
+      // By default ROS2 message orientation is 1.0, so need to set this
+      pose1.orientation.w = pose2.orientation.w = 0.9 * ii;
+    }
+  }
+};
+
+
+template<typename TEST_T_>
+class Ros2ToRos1SerializationTest : public testing::Test
+{
+public:
+  using TEST_T = TEST_T_;
+  using ROS1_T = typename TEST_T::ROS1_T;
+  using ROS2_T = typename TEST_T::ROS2_T;
+  using FACTORY_T = typename TEST_T::FACTORY_T;
+
+  TEST_T test;
+
+  void TestBody() {}
+};
+
+
+using Ros2ToRos1SerializationTypes = ::testing::Types<
+  Vector3Test,  // 0
+  StringTestEmpty,  // 1
+  StringTestHello,  // 2
+  TimeTest,  // 3
+  DurationTest,  // 4
+  HeaderTestEmpty,  // 5
+  HeaderTestBaseLink,  // 6
+  PoseTest,  // 7
+  PoseArrayTestEmpty,  // 8
+  PoseArrayTest  // 9
+>;
+TYPED_TEST_SUITE(Ros2ToRos1SerializationTest, Ros2ToRos1SerializationTypes);
+
+
+// cppcheck-suppress syntaxError
+TYPED_TEST(Ros2ToRos1SerializationTest, test_length)
+{
+  using FACTORY_T = typename TestFixture::FACTORY_T;
+  using ROS1_T = typename TestFixture::ROS1_T;
+  using ROS2_T = typename TestFixture::ROS2_T;
+  const ROS1_T & ros1_msg = this->test.ros1_msg;
+  const ROS2_T & ros2_msg = this->test.ros2_msg;
+  uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
+  uint32_t ros2_len = FACTORY_T::length_2_to_1_stream(ros2_msg);
+  EXPECT_EQ(ros1_len, ros2_len);
+}
+
+
+// cppcheck-suppress syntaxError
+TYPED_TEST(Ros2ToRos1SerializationTest, test_get_factory)
+{
+  // Make sure get_factory still works with Header and other types
+  const std::string & ros1_type_name = this->test.factory.ros1_type_name_;
+  const std::string & ros2_type_name = this->test.factory.ros2_type_name_;
+  std::shared_ptr<ros1_bridge::FactoryInterface> factory;
+  EXPECT_NO_THROW(factory = ros1_bridge::get_factory(ros1_type_name, ros2_type_name));
+  ASSERT_TRUE(static_cast<bool>(factory));
+}
+
+
+// cppcheck-suppress syntaxError
+TYPED_TEST(Ros2ToRos1SerializationTest, test_deserialization)
+{
+  using FACTORY_T = typename TestFixture::FACTORY_T;
+  using ROS1_T = typename TestFixture::ROS1_T;
+  using ROS2_T = typename TestFixture::ROS2_T;
+  const ROS1_T & ros1_msg = this->test.ros1_msg;
+  const ROS2_T & ros2_msg = this->test.ros2_msg;
+  const uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
+  std::vector<uint8_t> buffer(ros1_len);
+  ros::serialization::OStream out_stream(buffer.data(), ros1_len);
+  FACTORY_T::write_2_to_1_stream(out_stream, ros2_msg);
+  ros::serialization::IStream in_stream(buffer.data(), ros1_len);
+  ROS2_T ros2_msg2;
+  FACTORY_T::read_2_to_1_stream(in_stream, ros2_msg2);
+  EXPECT_TRUE(TestFixture::TEST_T::compare(ros2_msg, ros2_msg2));
+}
+
+
+// cppcheck-suppress syntaxError
+TYPED_TEST(Ros2ToRos1SerializationTest, test_serialization)
+{
+  using FACTORY_T = typename TestFixture::FACTORY_T;
+  using ROS1_T = typename TestFixture::ROS1_T;
+  using ROS2_T = typename TestFixture::ROS2_T;
+  const ROS1_T & ros1_msg = this->test.ros1_msg;
+  const ROS2_T & ros2_msg = this->test.ros2_msg;
+  const uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
+  const uint32_t ros2_len = FACTORY_T::length_2_to_1_stream(ros2_msg);
+  ASSERT_EQ(ros1_len, ros2_len);
+  const uint32_t len = ros1_len;
+
+  // Serialize both streams and check byte-by-byte the value match
+  const uint8_t guard_value = 0x42;
+
+  std::vector<uint8_t> buffer1(len + 1);
+  {
+    buffer1.at(len) = guard_value;
+    ros::serialization::OStream stream(buffer1.data(), len);
+    EXPECT_EQ(stream.getLength(), len);
+    ros::serialization::serialize(stream, ros1_msg);
+    // after serializating all the "capacity" should be used up
+    EXPECT_EQ(stream.getLength(), 0ul);
+    // Hacky check to make sure serialization didn't run over the end of the buffer
+    EXPECT_EQ(buffer1.at(len), guard_value);
+  }
+
+  std::vector<uint8_t> buffer2(len + 1);
+  {
+    buffer2.at(len) = guard_value;
+    ros::serialization::OStream stream(buffer2.data(), len);
+    EXPECT_EQ(stream.getLength(), len);
+    FACTORY_T::write_2_to_1_stream(stream, ros2_msg);
+    EXPECT_EQ(stream.getLength(), 0ul);
+    EXPECT_EQ(buffer2.at(len), guard_value);
+  }
+
+  unsigned mismatch_count = 0;
+  const unsigned max_mismatch_count = 0;
+  for (size_t idx = 0; idx < len; ++idx) {
+    unsigned val1 = buffer1.at(idx);
+    unsigned val2 = buffer2.at(idx);
+    EXPECT_EQ(val1, val2) << " idx=" << idx << " of " << len;
+    if (val1 != val2) {
+      ++mismatch_count;
+      ASSERT_LE(mismatch_count, max_mismatch_count);
+    }
+  }
+  ASSERT_EQ(mismatch_count, 0u);
+}
+
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_ros2_to_ros1_serialization.cpp
+++ b/test/test_ros2_to_ros1_serialization.cpp
@@ -364,7 +364,7 @@ TYPED_TEST(Ros2ToRos1SerializationTest, test_length)
   const ROS1_T & ros1_msg = this->test.ros1_msg;
   const ROS2_T & ros2_msg = this->test.ros2_msg;
   uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
-  uint32_t ros2_len = FACTORY_T::length_2_to_1_stream(ros2_msg);
+  uint32_t ros2_len = FACTORY_T::length_2_as_1_stream(ros2_msg);
   EXPECT_EQ(ros1_len, ros2_len);
 }
 
@@ -392,10 +392,10 @@ TYPED_TEST(Ros2ToRos1SerializationTest, test_deserialization)
   const uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
   std::vector<uint8_t> buffer(ros1_len);
   ros::serialization::OStream out_stream(buffer.data(), ros1_len);
-  FACTORY_T::write_2_to_1_stream(out_stream, ros2_msg);
+  FACTORY_T::convert_2_to_1(ros2_msg, out_stream);
   ros::serialization::IStream in_stream(buffer.data(), ros1_len);
   ROS2_T ros2_msg2;
-  FACTORY_T::read_2_to_1_stream(in_stream, ros2_msg2);
+  FACTORY_T::convert_1_to_2(in_stream, ros2_msg2);
   EXPECT_TRUE(TestFixture::TEST_T::compare(ros2_msg, ros2_msg2));
 }
 
@@ -409,7 +409,7 @@ TYPED_TEST(Ros2ToRos1SerializationTest, test_serialization)
   const ROS1_T & ros1_msg = this->test.ros1_msg;
   const ROS2_T & ros2_msg = this->test.ros2_msg;
   const uint32_t ros1_len = ros::serialization::serializationLength(ros1_msg);
-  const uint32_t ros2_len = FACTORY_T::length_2_to_1_stream(ros2_msg);
+  const uint32_t ros2_len = FACTORY_T::length_2_as_1_stream(ros2_msg);
   ASSERT_EQ(ros1_len, ros2_len);
   const uint32_t len = ros1_len;
 
@@ -433,7 +433,7 @@ TYPED_TEST(Ros2ToRos1SerializationTest, test_serialization)
     buffer2.at(len) = guard_value;
     ros::serialization::OStream stream(buffer2.data(), len);
     EXPECT_EQ(stream.getLength(), len);
-    FACTORY_T::write_2_to_1_stream(stream, ros2_msg);
+    FACTORY_T::convert_2_to_1(ros2_msg, stream);
     EXPECT_EQ(stream.getLength(), 0ul);
     EXPECT_EQ(buffer2.at(len), guard_value);
   }


### PR DESCRIPTION
## Short Description
Provide functions to potentially save some CPU when converting ROS messages by allow "direct" serialization of ROS2 message classes to ROS1 streams.

## Long Description
Currently, when ros1_bridge bridges a ROS2 topics to a ROS1 topics, it requires three steps
1. Deserialize ROS2 stream into a ROS2 message
2. Use convert_2_to_1 to copy members from ROS2 object to ROS1 message
3. Serialize ROS1 into ROS1 stream.

Using new feature removes a conversion step
1. Deserialize ROS2 stream into a ROS2 message
2. Serialize ROS2 into ROS1 stream.

Here's what the convert_2_to_1 function looks like geometry_msgs::Vector3
```C++
template<>
void Factory< ... >::convert_2_to_1(
  const geometry_msgs::msg::Vector3 & ros2_msg,
  geometry_msgs::Vector3 & ros1_msg)
{
  ros1_msg.x = ros2_msg.x;
  ros1_msg.y = ros2_msg.y;
  ros1_msg.z = ros2_msg.z;
}
```

Here's what the direct serialization function looks like (same internal function is used to implement read, write, and length)
```C++
template<>
template<typename STREAM_T, typename ROS2_MSG_T>
void
Factory<..>::msg_2_to_1_stream(
  STREAM_T& stream,
  ROS2_MSG_T& ros2_msg)
{
  stream.next(ros2_msg.x);
  stream.next(ros2_msg.y);
  stream.next(ros2_msg.z);
}
```

## Auto-Generated Code Examples

### PoseStamped
```C++
template<>
template<typename STREAM_T, typename ROS2_MSG_T>
void
Factory<...>::msg_2_to_1_stream(
  STREAM_T& stream,
  ROS2_MSG_T& ros2_msg)
{
  Factory<
    std_msgs::Header,
    std_msgs::msg::Header
  >::msg_2_to_1_stream(stream, ros2_msg.header);

  Factory<
    geometry_msgs::Pose,
    geometry_msgs::msg::Pose
  >::msg_2_to_1_stream(stream, ros2_msg.pose);
}
```

### sensor_msgs::Image

Message Definition
```
[sensor_msgs/Image]:
std_msgs/Header header
uint32 height
uint32 width
string encoding
uint8 is_bigendian
uint32 step
uint8[] data
```

Streaming Code
```C++
template<>
template<typename STREAM_T, typename ROS2_MSG_T>
void
Factory<...>::msg_2_to_1_stream(
  STREAM_T& stream,
  ROS2_MSG_T& ros2_msg)
{
  Factory<
    std_msgs::Header,
    std_msgs::msg::Header
  >::msg_2_to_1_stream(stream, ros2_msg.header);
  stream.next(ros2_msg.height);
  stream.next(ros2_msg.width);
  stream.next(ros2_msg.encoding);
  stream.next(ros2_msg.is_bigendian);
  stream.next(ros2_msg.step);
  streamVectorSize(stream, ros2_msg.data);
  streamPrimitiveVector(stream, ros2_msg.data);
}
```

### sensor_msgs::Imu

Imu message definition
```
std_msgs/Header header
geometry_msgs/Quaternion orientation
float64[9] orientation_covariance
geometry_msgs/Vector3 angular_velocity
float64[9] angular_velocity_covariance
geometry_msgs/Vector3 linear_acceleration
float64[9] linear_acceleration_covariance
```

Streaming code
```C++
template<>
template<typename STREAM_T, typename ROS2_MSG_T>
void
Factory<
  sensor_msgs::Imu,
  sensor_msgs::msg::Imu
>::msg_2_to_1_stream(STREAM_T& stream,
                     ROS2_MSG_T& ros2_msg)
{
  Factory<
    std_msgs::Header,
    std_msgs::msg::Header
  >::msg_2_to_1_stream(stream, ros2_msg.header);

  Factory<
    geometry_msgs::Quaternion,
    geometry_msgs::msg::Quaternion
  >::msg_2_to_1_stream(stream, ros2_msg.orientation);

  streamPrimitiveVector(stream, ros2_msg.orientation_covariance);

  Factory<
    geometry_msgs::Vector3,
    geometry_msgs::msg::Vector3
  >::msg_2_to_1_stream(stream, ros2_msg.angular_velocity);

  streamPrimitiveVector(stream, ros2_msg.angular_velocity_covariance);

  Factory<
    geometry_msgs::Vector3,
    geometry_msgs::msg::Vector3
  >::msg_2_to_1_stream(stream, ros2_msg.linear_acceleration);
  streamPrimitiveVector(stream, ros2_msg.linear_acceleration_covariance);
}
```

