### PR TITLE
Apply automatic mapping rules in case only package+message mapping exists

### DIFF
--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -789,6 +789,7 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
     # apply name based mapping of fields
     ros1_field_missing_in_ros2 = False
 
+    ros1_fields_not_mapped = []
     for ros1_field in ros1_spec.parsed_fields():
         for ros2_member in ros2_spec.structure.members:
             if ros1_field.name.lower() == ros2_member.name:
@@ -796,9 +797,13 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
                 update_ros1_field_information(ros1_field, ros1_msg.package_name)
                 mapping.add_field_pair(ros1_field, ros2_member)
                 break
-        else:
+    
+        ros1_fields_mapped_to_a_ros2_member = [field[0].name for field in mapping.fields_1_to_2.keys()]
+        if not ros1_field.name in ros1_fields_mapped_to_a_ros2_member:
             # this allows fields to exist in ROS 1 but not in ROS 2
-            ros1_field_missing_in_ros2 = True
+            ros1_fields_not_mapped += [ros1_field]
+
+    ros1_field_missing_in_ros2 = any(ros1_fields_not_mapped)
 
     if ros1_field_missing_in_ros2:
         # if some fields exist in ROS 1 but not in ROS 2

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -785,7 +785,6 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
                     file=sys.stderr)
                 continue
             mapping.add_field_pair(ros1_selected_fields, ros2_selected_fields)
-        return mapping
 
     # apply name based mapping of fields
     ros1_field_missing_in_ros2 = False

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -797,9 +797,11 @@ def determine_field_mapping(ros1_msg, ros2_msg, mapping_rules, msg_idx):
                 update_ros1_field_information(ros1_field, ros1_msg.package_name)
                 mapping.add_field_pair(ros1_field, ros2_member)
                 break
-    
-        ros1_fields_mapped_to_a_ros2_member = [field[0].name for field in mapping.fields_1_to_2.keys()]
-        if not ros1_field.name in ros1_fields_mapped_to_a_ros2_member:
+
+        ros1_fields_mapped_to_a_ros2_member = [field[0].name
+                                               for field
+                                               in mapping.fields_1_to_2.keys()]
+        if ros1_field.name not in ros1_fields_mapped_to_a_ros2_member:
             # this allows fields to exist in ROS 1 but not in ROS 2
             ros1_fields_not_mapped += [ros1_field]
 


### PR DESCRIPTION
In `determine_field_mapping`, there was an early return inside a loop over all mapping rules. If there were any mapping rules but they don't specify *field* mappings, the early return made the function return without creating field mappings automatically.

For a particular message type, ROS 1's uuid_msgs/UniqueID vs ROS 2's unique_identifier_msgs/UUID, the message definition is exactly the same but type name is not. The only mapping rule defined for `unique_identifier_msgs/UUID` is that it maps to `uuid_msgs/UniqueID`, but no *field* mappings are needed because the definitions are the same: https://github.com/ros2/unique_identifier_msgs/blob/rolling/mapping_rules.yaml

But, then we hit the early return (because the for-loop is ran without any rule applying to the message at hand and thus not `continue`-ing in a code branch handling a rule) and return without applying the normal automatic field mapping generation rules.

By removing the early return, the other rules are applied and the mapping rules for handling the exact same message definitions are applied.

This fixes the issue found in https://github.com/ros2/unique_identifier_msgs/pull/25 in `ros1_bridge` instead of `unique_identifier_msgs`

This PR applies to `foxy` because I combine it with Noetic and can test only that combo, but the early return causing this issue is still there on the main branch: https://github.com/ros2/ros1_bridge/blob/master/ros1_bridge/__init__.py#L788