### PR TITLE
Improved gitignore to exclude build files and similar editor-based tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,32 @@
+
+# Python Caching
 __pycache__
+
+# ROS2 Build Folders
+build/
+_build/
+log/
+install/
+
+# Editors
+.vscode
+.idea
+.#*
+.project
+.cproject
+
+*~ 
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+


### PR DESCRIPTION
The current gitignore file makes it difficult to include the repository as a submodule, if working inside a larger repository. 
Improving the gitignore file will make this easier and simplify testing while contributing to the project by also reducing the likelihood of an accidental push containing editor-specific config. 