### PR TITLE
Improve bridge command parser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Workaround for https://github.com/actions/runner-images/issues/675
+        run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
       - uses: ros-tooling/setup-ros@v0.5
         with:
           required-ros-distributions: "noetic rolling"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ on: [push, pull_request] # on all pushes and PRs
 
 jobs:
   ros1_bridge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/setup-ros@v0.5
         with:
           required-ros-distributions: "noetic rolling"
       - name: Build and test ros1-bridge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,18 +5,10 @@ on: [push, pull_request] # on all pushes and PRs
 jobs:
   ros1_bridge:
     runs-on: ubuntu-20.04
+    container:
+      image: ros:rolling-ros1-bridge
     steps:
       - uses: actions/checkout@v2
-      - name: Workaround for https://github.com/actions/runner-images/issues/675
-        run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
-      - uses: ros-tooling/setup-ros@v0.5
-        with:
-          required-ros-distributions: "noetic rolling"
       - name: Build and test ros1-bridge
-        uses: ros-tooling/action-ros-ci@v0.2
-        with:
-          package-name: ros1_bridge
-          target-ros1-distro: noetic
-          target-ros2-distro: rolling
-
+        run: |
+          /ros_entrypoint.sh colcon build --allow-overriding ros1_bridge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ add_library(${PROJECT_NAME} SHARED
   "src/builtin_interfaces_factories.cpp"
   "src/convert_builtin_interfaces.cpp"
   "src/bridge.cpp"
+  "src/command_parser_utils.cpp"
   ${generated_files})
 ament_target_dependencies(${PROJECT_NAME}
   ${prefixed_ros1_message_packages}

--- a/include/ros1_bridge/command_parser_utils.hpp
+++ b/include/ros1_bridge/command_parser_utils.hpp
@@ -1,0 +1,46 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS1_BRIDGE__COMMAND_PARSER_UTILS_HPP_
+#define ROS1_BRIDGE__COMMAND_PARSER_UTILS_HPP_
+
+#include <string>
+#include <vector>
+
+namespace ros1_bridge
+{
+
+bool find_command_option(
+    const std::vector<const char *> & args,
+    const std::string & option);
+
+bool get_flag_option(
+    std::vector<const char *> & args,
+    const std::string & option,
+    const char * & value,
+    bool remove = false);
+
+bool get_flag_option(
+    std::vector<const char *> & args,
+    const std::string & option,
+    bool remove = false);
+
+void split_ros1_ros2_args(
+  const std::vector<const char *> & args,
+  std::vector<const char *> & ros1_args,
+  std::vector<const char *> & ros2_args);
+
+}  // namespace ros1_bridge
+
+#endif  // ROS1_BRIDGE__COMMAND_PARSER_UTILS_HPP_

--- a/src/command_parser_utils.cpp
+++ b/src/command_parser_utils.cpp
@@ -1,0 +1,91 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros1_bridge/command_parser_utils.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+namespace ros1_bridge
+{
+
+bool find_command_option(const std::vector<const char *> & args, const std::string & option)
+{
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
+    });
+
+  return it != args.end();
+}
+
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, const char * & value, bool remove)
+{
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
+    });
+
+  if (it != args.end()) {
+    auto value_it = std::next(it);
+
+    if (value_it != args.end()) {
+      value = *value_it;
+
+      if (remove) {
+        args.erase(it);  // Remove option
+        args.erase(it);  // Remove value
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, bool remove)
+{
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
+    });
+
+  if (it != args.end()) {
+    if (remove) {
+      args.erase(it);
+    }
+    return true;
+  }
+
+  return false;
+}
+
+void split_ros1_ros2_args(
+  const std::vector<const char *> & args, std::vector<const char *> & ros1_args,
+  std::vector<const char *> & ros2_args)
+{
+  // Start iterating from the second argument, since the first argument is the executable name
+  auto it = std::find_if(args.begin() + 1, args.end(), [] (const char * const & element) {
+    return strcmp(element, "--ros-args") == 0;
+    });
+
+  if (it != args.end()) {
+    ros1_args = std::vector<const char *>(args.begin(), it);
+    ros2_args = std::vector<const char *>(it, args.end());
+    ros2_args.insert(ros2_args.begin(), args.at(0));
+  } else {
+    ros1_args = args;
+    ros2_args = args;
+  }
+}
+
+}  // namespace ros1_bridge

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -59,8 +59,8 @@ struct Bridge2to1HandlesAndMessageTypes
 
 bool find_command_option(const std::vector<const char *> & args, const std::string & option)
 {
-  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
-    return strcmp(element, option) == 0;
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
     });
 
   return it != args.end();
@@ -68,8 +68,8 @@ bool find_command_option(const std::vector<const char *> & args, const std::stri
 
 bool get_flag_option(std::vector<const char *> & args, const std::string & option, bool remove = false)
 {
-  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
-    return strcmp(element, option) == 0;
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
     });
 
   if (it != args.end()) {
@@ -87,7 +87,7 @@ void split_ros1_ros2_args(
   std::vector<const char *> & ros2_args)
 {
   // Start iterating from the second argument, since the first argument is the executable name
-  auto it = std::find_if(args.begin() + 1, args.end(), [] (const char * & element) {
+  auto it = std::find_if(args.begin() + 1, args.end(), [] (const char * const & element) {
     return strcmp(element, "--ros-args") == 0;
     });
 
@@ -499,8 +499,8 @@ int main(int argc, char * argv[])
   bool bridge_all_1to2_topics;
   bool bridge_all_2to1_topics;
 
-  std::vector<char *> ros1_args;
-  std::vector<char *> ros2_args;
+  std::vector<const char *> ros1_args;
+  std::vector<const char *> ros2_args;
 
   if (!parse_command_options(
       argc, argv, ros1_args, ros2_args, output_topic_introspection,
@@ -515,7 +515,8 @@ int main(int argc, char * argv[])
   auto ros2_node = rclcpp::Node::make_shared("ros_bridge");
 
   // ROS 1 node
-  ros::init(ros1_args.size(), ros1_args.data(), "ros_bridge");
+  int argc_ros1 = ros1_args.size();
+  ros::init(argc_ros1, const_cast<char **>(ros1_args.data()), "ros_bridge");
   ros::NodeHandle ros1_node;
 
   // mapping of available topic names to type names

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -57,22 +57,37 @@ struct Bridge2to1HandlesAndMessageTypes
   std::string ros2_type_name;
 };
 
-bool find_command_option(const std::vector<std::string> & args, const std::string & option)
+bool find_command_option(const std::vector<const char *> & args, const std::string & option)
 {
-  return std::find(args.begin(), args.end(), option) != args.end();
+  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
+    return strcmp(element, option) == 0;
+    });
+
+  return it != args.end();
 }
 
-bool get_flag_option(const std::vector<std::string> & args, const std::string & option)
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, bool & remove = false)
 {
-  auto it = std::find(args.begin(), args.end(), option);
-  return it != args.end();
+  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
+    return strcmp(element, option) == 0;
+    });
+
+  if (it != args.end()) {
+    if (remove) {
+      args.erase(it);
+    }
+    return true;
+  }
+
+  return false;
+}
 }
 
 bool parse_command_options(
   int argc, char ** argv, bool & output_topic_introspection,
   bool & bridge_all_1to2_topics, bool & bridge_all_2to1_topics)
 {
-  std::vector<std::string> args(argv, argv + argc);
+  std::vector<const char *> args(argv, argv + argc);
 
   if (find_command_option(args, "-h") || find_command_option(args, "--help")) {
     std::stringstream ss;

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -66,7 +66,7 @@ bool find_command_option(const std::vector<const char *> & args, const std::stri
   return it != args.end();
 }
 
-bool get_flag_option(std::vector<const char *> & args, const std::string & option, bool & remove = false)
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, bool remove = false)
 {
   auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
     return strcmp(element, option) == 0;

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -282,15 +282,6 @@ int main(int argc, char * argv[])
   const char * services_2_to_1_parameter_name = "services_2_to_1";
   const char * service_execution_timeout_parameter_name =
     "ros1_bridge/parameter_bridge/service_execution_timeout";
-  if (argc > 1) {
-    topics_parameter_name = argv[1];
-  }
-  if (argc > 2) {
-    services_1_to_2_parameter_name = argv[2];
-  }
-  if (argc > 3) {
-    services_2_to_1_parameter_name = argv[3];
-  }
 
   // Topics
   XmlRpc::XmlRpcValue topics;

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -231,16 +231,16 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
 
 bool find_command_option(const std::vector<const char *> & args, const std::string & option)
 {
-  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * & element) {
     return strcmp(element, option) == 0;
     });
 
   return it != args.end();
 }
 
-bool get_flag_option(std::vector<const char *> & args, const std::string & option, char * & value, bool & remove = false)
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, char * & value, bool remove = false)
 {
-  auto it = std::find_if(args.begin(), args.end(), [] (const char * & element) {
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * & element) {
     return strcmp(element, option) == 0;
     });
 
@@ -283,8 +283,8 @@ void split_ros1_ros2_args(
 
 bool parse_command_options(
   int argc, char ** argv, std::vector<const char *> & ros1_args,
-  std::vector<const char *> & ros2_args, const char * & topics_parameter_name,
-  const char * & services_1_to_2_parameter_name, const char * & services_2_to_1_parameter_name)
+  std::vector<const char *> & ros2_args, char * & topics_parameter_name,
+  char * & services_1_to_2_parameter_name, char * & services_2_to_1_parameter_name)
 {
   topics_parameter_name = "topics";
   services_1_to_2_parameter_name = "services_1_to_2";
@@ -334,13 +334,13 @@ int main(int argc, char * argv[])
   // topic: the name of the topic to bridge (e.g. '/topic_name')
   // type: the type of the topic to bridge (e.g. 'pkgname/msg/MsgName')
   // queue_size: the queue size to use (default: 100)
-  const char * topics_parameter_name;
+  char * topics_parameter_name;
   // the services parameters need to be arrays
   // and each item needs to be a dictionary with the following keys;
   // service: the name of the service to bridge (e.g. '/service_name')
   // type: the type of the service to bridge (e.g. 'pkgname/srv/SrvName')
-  const char * services_1_to_2_parameter_name;
-  const char * services_2_to_1_parameter_name;
+  char * services_1_to_2_parameter_name;
+  char * services_2_to_1_parameter_name;
   const char * service_execution_timeout_parameter_name =
     "ros1_bridge/parameter_bridge/service_execution_timeout";
 

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -252,7 +252,8 @@ int main(int argc, char * argv[])
 {
   std::vector<const char *> ros1_args;
   std::vector<const char *> ros2_args;
-  split_ros1_ros2_args(std::vector<const char *>(argv, argv + argc), ros1_args, ros2_args);
+  std::vector<const char *> args(argv, argv + argc);
+  split_ros1_ros2_args(args, ros1_args, ros2_args);
 
   // ROS 1 node
   ros::init(ros1_args.size(), ros1_args.data(), "ros_bridge");

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -231,17 +231,17 @@ rclcpp::QoS qos_from_params(XmlRpc::XmlRpcValue qos_params)
 
 bool find_command_option(const std::vector<const char *> & args, const std::string & option)
 {
-  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * & element) {
-    return strcmp(element, option) == 0;
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
     });
 
   return it != args.end();
 }
 
-bool get_flag_option(std::vector<const char *> & args, const std::string & option, char * & value, bool remove = false)
+bool get_flag_option(std::vector<const char *> & args, const std::string & option, const char * & value, bool remove = false)
 {
-  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * & element) {
-    return strcmp(element, option) == 0;
+  auto it = std::find_if(args.begin(), args.end(), [&option] (const char * const & element) {
+    return strcmp(element, option.c_str()) == 0;
     });
 
   if (it != args.end()) {
@@ -267,7 +267,7 @@ void split_ros1_ros2_args(
   std::vector<const char *> & ros2_args)
 {
   // Start iterating from the second argument, since the first argument is the executable name
-  auto it = std::find_if(args.begin() + 1, args.end(), [] (const char * & element) {
+  auto it = std::find_if(args.begin() + 1, args.end(), [] (const char * const & element) {
     return strcmp(element, "--ros-args") == 0;
     });
 
@@ -283,8 +283,8 @@ void split_ros1_ros2_args(
 
 bool parse_command_options(
   int argc, char ** argv, std::vector<const char *> & ros1_args,
-  std::vector<const char *> & ros2_args, char * & topics_parameter_name,
-  char * & services_1_to_2_parameter_name, char * & services_2_to_1_parameter_name)
+  std::vector<const char *> & ros2_args, const char * & topics_parameter_name,
+  const char * & services_1_to_2_parameter_name, const char * & services_2_to_1_parameter_name)
 {
   topics_parameter_name = "topics";
   services_1_to_2_parameter_name = "services_1_to_2";
@@ -334,13 +334,13 @@ int main(int argc, char * argv[])
   // topic: the name of the topic to bridge (e.g. '/topic_name')
   // type: the type of the topic to bridge (e.g. 'pkgname/msg/MsgName')
   // queue_size: the queue size to use (default: 100)
-  char * topics_parameter_name;
+  const char * topics_parameter_name;
   // the services parameters need to be arrays
   // and each item needs to be a dictionary with the following keys;
   // service: the name of the service to bridge (e.g. '/service_name')
   // type: the type of the service to bridge (e.g. 'pkgname/srv/SrvName')
-  char * services_1_to_2_parameter_name;
-  char * services_2_to_1_parameter_name;
+  const char * services_1_to_2_parameter_name;
+  const char * services_2_to_1_parameter_name;
   const char * service_execution_timeout_parameter_name =
     "ros1_bridge/parameter_bridge/service_execution_timeout";
 
@@ -351,7 +351,8 @@ int main(int argc, char * argv[])
   }
 
   // ROS 1 node
-  ros::init(ros1_args.size(), ros1_args.data(), "ros_bridge");
+  int argc_ros1 = ros1_args.size();
+  ros::init(argc_ros1, const_cast<char **>(ros1_args.data()), "ros_bridge");
   ros::NodeHandle ros1_node;
 
   // ROS 2 node

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -245,14 +245,14 @@ bool get_flag_option(std::vector<const char *> & args, const std::string & optio
     });
 
   if (it != args.end()) {
-    auto value_it = it++;
+    auto value_it = std::next(it);
 
     if (value_it != args.end()) {
       value = *value_it;
 
       if (remove) {
-        args.erase(it);
-        args.erase(value_it);
+        args.erase(it);  // Remove option
+        args.erase(it);  // Remove value
       }
 
       return true;
@@ -306,16 +306,16 @@ bool parse_command_options(
     return false;
   }
 
-  if (get_flag_option(args, "--topics", topics_parameter_name, true)) {
-    printf("Using default topics parameter name: %s", topics_parameter_name);
+  if (!get_flag_option(args, "--topics", topics_parameter_name, true)) {
+    printf("Using default topics parameter name: %s\n", topics_parameter_name);
   }
 
-  if (get_flag_option(args, "--services_1_to_2", services_1_to_2_parameter_name, true)) {
-    printf("Using default services_1_to_2 parameter name: %s", services_1_to_2_parameter_name);
+  if (!get_flag_option(args, "--services-1-to-2", services_1_to_2_parameter_name, true)) {
+    printf("Using default services 1 to 2 parameter name: %s\n", services_1_to_2_parameter_name);
   }
 
-  if (get_flag_option(args, "--services_2_to_1", services_2_to_1_parameter_name, true)) {
-    printf("Using default services_2_to_1 parameter name: %s", services_2_to_1_parameter_name);
+  if (!get_flag_option(args, "--services-2-to-1", services_2_to_1_parameter_name, true)) {
+    printf("Using default services 2 to 1 parameter name: %s\n", services_2_to_1_parameter_name);
   }
 
   split_ros1_ros2_args(args, ros1_args, ros2_args);


### PR DESCRIPTION
This PR attempts to improve the usability of the dynamic bridge and the parameter bridge by splitting the ROS1 and ROS2 arguments into two separate lists of arguments. This solves the issue #316 and also enables the possibility to set namespaces, node names, remappings, etc, for the ROS1 node and for the ROS2 node, isolatting the ROS1 arguments from the ROS2 argumetns. Additionaly the command parser from the parameter bridge was fixed in order to be more similar to the dynamic bridge. 

Besides that, I made some changes to the GitHub, witch can be discussed, in order to simplify the setup of the environment where the package is built for the GitHub Action.