### PR TITLE
Remove xmlrpcpp from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,6 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>xmlrpcpp</build_depend>
 
   <buildtool_export_depend>pkg-config</buildtool_export_depend>
 


### PR DESCRIPTION
https://github.com/ros2/ros1_bridge/pull/401 added a dependency which should not be handled by rosdep, so removing from package.xml