### PR TITLE
Support tf_static 2to1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros1_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.9.7 (2023-05-27)
+------------------
 * remove xmlrpcpp from package.xml (`#406 <https://github.com/ros2/ros1_bridge/issues/406>`_)
 * Parametrization of `parameter_bridge` quality of service [Port of the commits (ec44770) and (86b4245) to foxy branch] (`#401 <https://github.com/ros2/ros1_bridge/issues/401>`_)
 * Contributors: Dharini Dutia, Lucyanno Frota

--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -116,6 +116,7 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latch,
   rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
 
 BridgeHandles

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros1_bridge</name>
-  <version>0.9.6</version>
+  <version>0.9.7</version>
   <description>A simple bridge between ROS 1 and ROS 2</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -79,6 +79,7 @@ create_bridge_from_2_to_1(
   rclcpp::PublisherBase::SharedPtr ros2_pub)
 {
   auto subscriber_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(subscriber_queue_size));
+  auto publisher_latch = false;
   return create_bridge_from_2_to_1(
     ros2_node,
     ros1_node,
@@ -88,6 +89,7 @@ create_bridge_from_2_to_1(
     ros1_type_name,
     ros1_topic_name,
     publisher_queue_size,
+    publisher_latch,
     ros2_pub);
 }
 
@@ -101,11 +103,12 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latch,
   rclcpp::PublisherBase::SharedPtr ros2_pub)
 {
   auto factory = get_factory(ros1_type_name, ros2_type_name);
   auto ros1_pub = factory->create_ros1_publisher(
-    ros1_node, ros1_topic_name, publisher_queue_size);
+    ros1_node, ros1_topic_name, publisher_queue_size, publisher_latch);
 
   auto ros2_sub = factory->create_ros2_subscriber(
     ros2_node, ros2_topic_name, subscriber_qos, ros1_pub, ros2_pub);

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -254,11 +254,20 @@ void update_bridge(
     bridge.ros1_type_name = ros1_type_name;
     bridge.ros2_type_name = ros2_type_name;
 
+    auto ros2_subscriber_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+    auto ros_publisher_latch = false;
+    if (topic_name == "/tf_static") {
+      ros2_subscriber_qos.keep_all();
+      ros2_subscriber_qos.transient_local();
+      ros2_subscriber_qos.reliable();
+      ros_publisher_latch = true;
+    }
+
     try {
       bridge.bridge_handles = ros1_bridge::create_bridge_from_2_to_1(
         ros2_node, ros1_node,
-        bridge.ros2_type_name, topic_name, 10,
-        bridge.ros1_type_name, topic_name, 10);
+        bridge.ros2_type_name, topic_name, ros2_subscriber_qos,
+        bridge.ros1_type_name, topic_name, 10, ros_publisher_latch);
     } catch (std::runtime_error & e) {
       fprintf(
         stderr,


### PR DESCRIPTION
## Changes

This PR allows to use of `dynamic_bridge` with `/tf_static` topic in the 2to1 direction of bridging.
Due to an invalid qos policy, the ROS2 subscriber created by the bridge was not able to receive the `tf_static` message. Furthermore, the ROS publisher wasn't latching the message.

- For tf_static bridging in 2to1 direction special rules are applied
- ROS2 subscriber special qos (reliable, keep all, transient local)
- ROS publisher latching enabled