### PR TITLE
Add special case in parameter bridge for `tf_static`

### DIFF
--- a/include/ros1_bridge/bridge.hpp
+++ b/include/ros1_bridge/bridge.hpp
@@ -116,6 +116,7 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latch,
   rclcpp::PublisherBase::SharedPtr ros2_pub = nullptr);
 
 BridgeHandles
@@ -135,6 +136,7 @@ create_bidirectional_bridge(
   const std::string & ros2_type_name,
   const std::string & topic_name,
   size_t queue_size,
+  bool publisher_latch,
   const rclcpp::QoS & publisher_qos);
 
 }  // namespace ros1_bridge

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -79,6 +79,7 @@ create_bridge_from_2_to_1(
   rclcpp::PublisherBase::SharedPtr ros2_pub)
 {
   auto subscriber_qos = rclcpp::SensorDataQoS(rclcpp::KeepLast(subscriber_queue_size));
+  auto publisher_latch = false;
   return create_bridge_from_2_to_1(
     ros2_node,
     ros1_node,
@@ -88,6 +89,7 @@ create_bridge_from_2_to_1(
     ros1_type_name,
     ros1_topic_name,
     publisher_queue_size,
+    publisher_latch,
     ros2_pub);
 }
 
@@ -101,11 +103,12 @@ create_bridge_from_2_to_1(
   const std::string & ros1_type_name,
   const std::string & ros1_topic_name,
   size_t publisher_queue_size,
+  bool publisher_latch,
   rclcpp::PublisherBase::SharedPtr ros2_pub)
 {
   auto factory = get_factory(ros1_type_name, ros2_type_name);
   auto ros1_pub = factory->create_ros1_publisher(
-    ros1_node, ros1_topic_name, publisher_queue_size);
+    ros1_node, ros1_topic_name, publisher_queue_size, publisher_latch);
 
   auto ros2_sub = factory->create_ros2_subscriber(
     ros2_node, ros2_topic_name, subscriber_qos, ros1_pub, ros2_pub);
@@ -147,6 +150,7 @@ create_bidirectional_bridge(
   const std::string & ros2_type_name,
   const std::string & topic_name,
   size_t queue_size,
+  bool publisher_latch,
   const rclcpp::QoS & publisher_qos)
 {
   RCLCPP_INFO(
@@ -158,7 +162,7 @@ create_bidirectional_bridge(
     ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, publisher_qos);
   handles.bridge2to1 = create_bridge_from_2_to_1(
     ros2_node, ros1_node,
-    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size, publisher_latch,
     handles.bridge1to2.ros2_publisher);
   return handles;
 }

--- a/src/parameter_bridge.cpp
+++ b/src/parameter_bridge.cpp
@@ -287,12 +287,22 @@ int main(int argc, char * argv[])
         topic_name.c_str(), type_name.c_str());
 
       try {
-        if (topics[i].hasMember("qos")) {
+        if (topic_name == "/tf_static")
+        {
+          bool publisher_latch = true;
           printf("Setting up QoS for '%s': ", topic_name.c_str());
           auto qos_settings = qos_from_params(topics[i]["qos"]);
           printf("\n");
           ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
-            ros1_node, ros2_node, "", type_name, topic_name, queue_size, qos_settings);
+            ros1_node, ros2_node, "", type_name, topic_name, queue_size, publisher_latch, qos_settings);
+          all_handles.push_back(handles);
+        }
+        else if (topics[i].hasMember("qos")) {
+          printf("Setting up QoS for '%s': ", topic_name.c_str());
+          auto qos_settings = qos_from_params(topics[i]["qos"]);
+          printf("\n");
+          ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(
+            ros1_node, ros2_node, "", type_name, topic_name, queue_size, false, qos_settings);
           all_handles.push_back(handles);
         } else {
           ros1_bridge::BridgeHandles handles = ros1_bridge::create_bidirectional_bridge(


### PR DESCRIPTION

This PR adds a special case in the bidirectional parameter bridge for the `tf_static` topic.
This modification was made as part of a requirement to get the `tf_static` topic from ROS 2 into ROS 1 as a latched topic.

Making this PR in case this is of use to anyone else.

Suggestions for improvement are welcome


**Known limitations:**

The bridge connection from ROS 2 -> ROS 1 seems to be made only if the ROS 1 subscriber is running before the ROS 2 publisher.
However, for the ROS 1 - > ROS 2 direction, the connection is immediately  made when the ROS 2 publisher is active even without a subscriber.

