### PR TITLE
Adding compatibility matrix to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ Therefore it can't be used with the dynamic bridge if no other subscribers are p
 As an alternative you can use the `--bridge-all-2to1-topics` option to bridge all ROS 2 topics to ROS 1 so that tools such as `rostopic echo`, `rostopic list` and `rqt` will see the topics even if there are no matching ROS 1 subscribers.
 Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
+## Supported ROS and Ubuntu Versions
+
+> ⚠️ **Important Compatibility Notice**
+
+- `ros1_bridge` **requires ROS 1**, which has reached [end-of-life (EOL)](https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025) as of **May 2025** for ROS Noetic.
+- Ubuntu **24.04 LTS** does **not support ROS 1**, and therefore is **not compatible** with `ros1_bridge`.
+
+| Ubuntu Version | Supported ROS 1 Versions  | Supported ROS 2 Versions              | `ros1_bridge` Support            |
+|----------------|----------------|---------------------------------------|----------------------------------|
+| 20.04 (Focal)  | Noetic Ninjemys   | Foxy Fitzroy (EOL), Galactic Geochelone (EOL), Humble Hawksbill    | ✅ Full support                  |
+| 22.04 (Jammy)  | ⚠️ Partial (unsupported officially) | Humble Hawksbill, Iron Irwini | ⚠️ Requires building from source |
+| 24.04 (Noble)  | ❌ Not available | Jazzy Jalisco, Kilted Kaiju          | ❌ Not supported                 |
+
+To use `ros1_bridge`, you must use a system where both ROS 1 and ROS 2 are installable and buildable. Mixing ROS distributions across unsupported Ubuntu versions is **not recommended** and may lead to broken builds or missing dependencies.
+
+
+
 ## Prerequisites
 
 In order to run the bridge you need to either:

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Run `ros2 run ros1_bridge dynamic_bridge -- --help` for more options.
 
 To use `ros1_bridge`, you must use a system where both ROS 1 and ROS 2 are installable and buildable. Mixing ROS distributions across unsupported Ubuntu versions is **not recommended** and may lead to broken builds or missing dependencies.
 
-
-
 ## Prerequisites
 
 In order to run the bridge you need to either:


### PR DESCRIPTION
Summary

This PR updates the README to clarify ros1_bridge compatibility with ROS and Ubuntu versions, particularly in light of ROS 1 reaching end-of-life and Ubuntu 24.04 dropping ROS 1 support.
- Changes Made    
Added a "Supported ROS and Ubuntu Versions" section with a compatibility matrix.    
Clarified that ROS 1 Noetic is the only supported ROS 1 version for Ubuntu 20.04.    
Explained that Ubuntu 24.04 does not support ROS 1, making it incompatible with ros1_bridge.    
Included supported ROS 2 distributions per Ubuntu release (including Kilted Kaiju for Ubuntu 24.04).    
Improved wording for clarity and accuracy.

- Motivation
To help users avoid compatibility issues when setting up ros1_bridge, especially with newer Ubuntu versions and unsupported ROS 1 installations.

-  Notes
This change is documentation-only.    
No functionality or code logic has been modified.