### PR TITLE
limiting the bridge to only create ROS 1 to ROS 2 handlers

### DIFF
--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -132,10 +132,10 @@ create_bidirectional_bridge(
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,
     ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, queue_size);
-  handles.bridge2to1 = create_bridge_from_2_to_1(
-    ros2_node, ros1_node,
-    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
-    handles.bridge1to2.ros2_publisher);
+  // handles.bridge2to1 = create_bridge_from_2_to_1(
+  //   ros2_node, ros1_node,
+  //   ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+  //   handles.bridge1to2.ros2_publisher);
   return handles;
 }
 
@@ -156,10 +156,10 @@ create_bidirectional_bridge(
   handles.bridge1to2 = create_bridge_from_1_to_2(
     ros1_node, ros2_node,
     ros1_type_name, topic_name, queue_size, ros2_type_name, topic_name, publisher_qos);
-  handles.bridge2to1 = create_bridge_from_2_to_1(
-    ros2_node, ros1_node,
-    ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
-    handles.bridge1to2.ros2_publisher);
+  // handles.bridge2to1 = create_bridge_from_2_to_1(
+  //   ros2_node, ros1_node,
+  //   ros2_type_name, topic_name, queue_size, ros1_type_name, topic_name, queue_size,
+  //   handles.bridge1to2.ros2_publisher);
   return handles;
 }
 


### PR DESCRIPTION
## Description

As part of our investigation into improving the runtime performance of the Vision-Based Landing system, we identified performance limitations in ros1_bridge. For instance, for a 50 Hz input INS data stream, the bridge was only forwarding messages at approximately 35 Hz. By switching to a unidirectional configuration (i.e., disabling unnecessary ROS 2 to ROS 1 transfers) and using static bridging, we observed a significant improvement in runtime performance.

This PR disables the creation of ROS 2 to ROS 1 handlers, limiting the bridge to only create ROS 1 to ROS 2 handlers (i.e., converting messages from ROS 1 to ROS 2 only).

## Test
As part of our testing, we increased the system CPU frequency and split topics across multiple bridge executables. Specifically, we isolated the 500 Hz topic into a dedicated static bridge executable, while routing all remaining topics through the existing parameter_bridge. This approach resulted in full 50 Hz throughput for the NavState topic and over 450 Hz throughput for the 500 Hz ROS 1 topic. Upcoming PRs will address enabling CPU performance mode and further optimizing bridge node deployment by separating topics.